### PR TITLE
feat(connectors): add Azure Tenant Connector

### DIFF
--- a/Connectors/Azure/AzureTenantConnector/.gitignore
+++ b/Connectors/Azure/AzureTenantConnector/.gitignore
@@ -1,0 +1,15 @@
+# Credentials — never commit
+config.json
+.env
+
+# Output files
+logs/
+connector_state_*.csv
+connector_delete_*.csv
+connector_orphans_*.csv
+connector_report_*.json
+
+# Python
+__pycache__/
+*.pyc
+.venv/

--- a/Connectors/Azure/AzureTenantConnector/README.md
+++ b/Connectors/Azure/AzureTenantConnector/README.md
@@ -1,0 +1,593 @@
+# Azure → Qualys Tenant Connector
+
+A Python CLI that discovers every active subscription in an Azure tenant and automatically creates a Qualys cloud connector for each one. Supports **Azure Government** and **Azure Commercial** clouds, all 14 Qualys platforms, and full lifecycle management (create, list, status, disable orphans, restore, delete).
+
+---
+
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Configuration](#configuration)
+  - [Azure Section](#azure-section)
+  - [Qualys Section](#qualys-section)
+  - [Qualys Platforms](#qualys-platforms)
+- [CLI Reference](#cli-reference)
+  - [Global Flags](#global-flags)
+  - [create](#create)
+  - [list](#list)
+  - [status](#status)
+  - [list-mgs](#list-mgs)
+  - [delete](#delete)
+  - [restore-orphans](#restore-orphans)
+- [Orphan Detection](#orphan-detection)
+- [Output Files](#output-files)
+- [Security Notes](#security-notes)
+
+---
+
+## How It Works
+
+```
+Azure Tenant
+    └── Management Groups (tree)
+            └── Subscriptions  ──►  Qualys Azure Connector (1 per subscription)
+```
+
+1. Authenticates to Azure using a Service Principal
+2. Walks the Management Group hierarchy under `rootMg` (or the entire tenant if not set)
+3. Collects all active subscriptions
+4. For each subscription, calls the Qualys Connectors API to create an `AzureAssetDataConnector`
+5. Skips subscriptions that already have a connector (idempotent)
+6. Optionally resolves/creates Qualys tags and applies them to connectors and discovered assets
+7. Fetches live connector state after creation and saves everything to CSV
+
+---
+
+## Prerequisites
+
+| Requirement | Detail |
+|---|---|
+| Python | 3.10 or later |
+| Azure Service Principal | See permissions below |
+| Qualys account | Connectors module enabled on your platform |
+
+### Azure SP permissions
+
+The Service Principal needs read access to Management Groups and their subscriptions.
+
+**Recommended — custom role at tenant root MG scope:**
+
+```json
+{
+  "roleName": "QualysOrgConnector",
+  "actions": [
+    "Microsoft.Management/managementGroups/read",
+    "Microsoft.Management/managementGroups/subscriptions/read"
+  ]
+}
+```
+
+Assign this role at `/providers/Microsoft.Management/managementGroups/<tenant-root-id>`.
+
+**Fallback — subscription-level Reader:**
+
+If the SP only has `Reader` on individual subscriptions, the script falls back to the Azure Subscriptions API automatically. Management group info will not be shown, but connector creation works normally.
+
+---
+
+## Setup
+
+```bash
+git clone <repo-url>
+cd azure-gov-tenant-connector
+
+# Create virtual environment
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Create your config
+cp config.example.json config.json
+# Edit config.json with your credentials and settings
+```
+
+---
+
+## Configuration
+
+All runtime settings live in `config.json`. The only CLI arguments are `--config`, `--output-dir`, and subcommand-specific flags (see [CLI Reference](#cli-reference)).
+
+> **Security:** `config.json` contains credentials. Never commit it to version control. It is included in `.gitignore` by default, and the script will warn you at startup if it detects the file is not gitignored.
+
+### Minimal config (required fields only)
+
+```json
+{
+  "azure": {
+    "tenantId":     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId":     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientSecret": "your-sp-client-secret"
+  },
+  "qualys": {
+    "username": "your-qualys-username",
+    "password": "your-qualys-password",
+    "platform": "US2"
+  }
+}
+```
+
+### Full config with all options
+
+```json
+{
+  "azure": {
+    "tenantId":     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId":     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientSecret": "your-sp-client-secret",
+    "rootMg":       "MyRootMG"
+  },
+  "qualys": {
+    "username":       "your-qualys-username",
+    "password":       "your-qualys-password",
+    "platform":       "US2",
+    "appType":        "cspm",
+    "activation":     ["VM", "PC"],
+    "runFrequency":   1440,
+    "isGovCloud":     false,
+    "disableOrphans": false,
+    "connectorTags":  ["azure-commercial", "production"],
+    "assetTags":      ["azure-asset", "cloud-discovery"]
+  }
+}
+```
+
+### Azure Section
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `tenantId` | **Yes** | — | Azure tenant (directory) ID |
+| `clientId` | **Yes** | — | Service Principal application (client) ID |
+| `clientSecret` | **Yes** | — | Service Principal secret value |
+| `rootMg` | No | `null` | Management Group name to scope discovery. `null` = entire tenant. Run `list-mgs` to find available names. |
+
+### Qualys Section
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `username` | **Yes** | — | Qualys login username |
+| `password` | **Yes** | — | Qualys login password |
+| `platform` | **Yes** | — | Qualys platform key (e.g. `"US2"`) or a full base URL. See [Qualys Platforms](#qualys-platforms). |
+| `appType` | No | `"cspm"` | Connector type. `"cspm"` enables Cloud Security Assessment; `"asset-inventory"` enables asset discovery only. |
+| `activation` | No | `[]` (none) | List of Qualys modules to activate. Valid values: `VM` (Vulnerability Management), `PC` (Policy Compliance), `SCA` (Security Configuration Assessment), `CERTVIEW`. **Note:** `PC` and `SCA` are mutually exclusive — choose one. |
+| `runFrequency` | No | `1440` | How often Qualys syncs the connector, in minutes. Default is 1440 (24 hours). |
+| `isGovCloud` | No | `true` | `true` = Azure Government (`login.microsoftonline.us`). `false` = Azure Commercial (`login.microsoftonline.com`). |
+| `disableOrphans` | No | `false` | When `true`, connectors for subscriptions no longer in scope are automatically disabled on each `create` run. See [Orphan Detection](#orphan-detection). |
+| `connectorTags` | No | `[]` | Tag names to apply to the **connector object** in Qualys. Tags are created automatically if they don't exist. |
+| `assetTags` | No | `[]` | Tag names to apply to **assets discovered** by the connector. |
+
+### Qualys Platforms
+
+| Key | Region | API Base URL |
+|---|---|---|
+| `US1` | United States 1 | `qualysapi.qualys.com` |
+| `US2` | United States 2 | `qualysapi.qg2.apps.qualys.com` |
+| `US3` | United States 3 | `qualysapi.qg3.apps.qualys.com` |
+| `US4` | United States 4 | `qualysapi.qg4.apps.qualys.com` |
+| `GOV1` | US Government | `qualysapi.gov1.qualys.us` |
+| `EU1` | Europe 1 | `qualysapi.qualys.eu` |
+| `EU2` | Europe 2 | `qualysapi.qg2.apps.qualys.eu` |
+| `EU3` | Europe 3 | `qualysapi.qg3.apps.qualys.it` |
+| `IN1` | India | `qualysapi.qg1.apps.qualys.in` |
+| `CA1` | Canada | `qualysapi.qg1.apps.qualys.ca` |
+| `AE1` | UAE | `qualysapi.qg1.apps.qualys.ae` |
+| `UK1` | United Kingdom | `qualysapi.qg1.apps.qualys.co.uk` |
+| `AU1` | Australia | `qualysapi.qg1.apps.qualys.com.au` |
+| `KSA1` | Saudi Arabia | `qualysapi.qg1.apps.qualysksa.com` |
+
+**Custom platform:** Set `platform` to a full URL to use a private or non-standard endpoint:
+
+```json
+"platform": "https://qualysapi.internal.example.com"
+```
+
+Not sure which platform you're on? Log in to the Qualys UI and check the URL in your browser, or visit [qualys.com/platform-identification](https://www.qualys.com/platform-identification/).
+
+---
+
+## CLI Reference
+
+```
+python main.py [--config FILE] [--output-dir DIR] <command> [options]
+```
+
+### Global Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--config FILE` | `config.json` | Path to your config file |
+| `--output-dir DIR` | `.` (current directory) | Directory where all CSVs and logs are written. Created automatically if it doesn't exist. Useful for organising runs by date or environment. |
+
+---
+
+### `create`
+
+Discovers Azure subscriptions and creates a Qualys connector for each one.
+
+```bash
+python main.py create [--dry-run] [--parallel N]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--dry-run` | off | Enumerate Azure subscriptions only. No Qualys API calls are made. Useful for previewing scope before a live run. |
+| `--parallel N` | `1` | Number of concurrent connector creation threads. Default is 1 (sequential). Submissions are always paced 2 seconds apart regardless of parallelism to avoid Qualys rate limits. |
+
+**Behaviour:**
+- Skips subscriptions that already have a connector (idempotent — safe to re-run)
+- If `disableOrphans: true`, runs orphan detection **before** creating new connectors
+- Fetches live connector state after creation and saves to CSV
+
+**Examples:**
+
+```bash
+# Preview what would be created
+python main.py create --dry-run
+
+# Live run, sequential
+python main.py create
+
+# Live run, 3 concurrent threads
+python main.py create --parallel 3
+
+# Separate output per environment
+python main.py --config config-prod.json --output-dir runs/prod create
+python main.py --config config-dev.json  --output-dir runs/dev  create
+```
+
+**Sample output:**
+
+```
+  #    Subscription ID                        Connector Name                             MG
+  ─────────────────────────────────────────────────────────────────────────────────────────
+  1    aaa-bbb-ccc-ddd-...                    My Production Sub                          prod-mg
+  2    eee-fff-ggg-hhh-...                    Dev Environment                            dev-mg
+
+=================================================================
+  Summary — 2026-05-18 16:30 UTC
+=================================================================
+  Total          : 2
+  Created        : 2
+  Already existed: 0
+  Failed         : 0
+
+  Created:
+    ✓ [657901] My Production Sub (aaa-bbb-ccc-ddd-...)
+    ✓ [657902] Dev Environment (eee-fff-ggg-hhh-...)
+=================================================================
+```
+
+---
+
+### `list`
+
+Lists all Azure connectors currently in Qualys with their live state.
+
+```bash
+python main.py list [--subscription ID]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--subscription ID` | (all) | Filter results to connectors whose subscription ID contains this string (substring match) |
+
+**Example:**
+
+```bash
+# List all
+python main.py list
+
+# Filter to a specific subscription
+python main.py list --subscription aaa-bbb-ccc
+```
+
+**Sample output:**
+
+```
+  ID         Name                          Subscription ID                        State             Disabled
+  ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+  657901     My Production Sub             aaa-bbb-ccc-ddd-...                    FINISHED_SUCCESS  false
+  657902     Dev Environment               eee-fff-ggg-hhh-...                    QUEUED            false
+
+  Total: 2 connector(s)
+```
+
+**Connector states:**
+
+| State | Meaning |
+|---|---|
+| `QUEUED` | Connector created, waiting for first sync |
+| `PROCESSING` | Sync in progress |
+| `FINISHED_SUCCESS` | Last sync completed successfully |
+| `FINISHED_ERRORS` | Last sync completed with errors |
+
+---
+
+### `status`
+
+Shows detailed live state for one or more specific connectors.
+
+```bash
+python main.py status --ids <ID> [<ID> ...]
+```
+
+**Example:**
+
+```bash
+python main.py status --ids 657901 657902
+```
+
+**Sample output:**
+
+```
+  Connector 657901:
+    State          : FINISHED_SUCCESS
+    Last Synced    : 2026-05-18T16:45:00Z
+    Assets Created : 42
+    Assets Updated : 0
+    Assets Deleted : 0
+    Error          : (none)
+    Disabled       : false
+    Run Frequency  : 1440 min
+```
+
+---
+
+### `list-mgs`
+
+Prints the Management Group hierarchy for your tenant as a tree. Use this to find the right value for `azure.rootMg` in your config.
+
+```bash
+python main.py list-mgs
+```
+
+**Sample output:**
+
+```
+  Management Group hierarchy — tenant abc123:
+
+  └── Tenant Root Group  [abc123]
+      ├── Production  [prod-mg]
+      │   ├── sub-prod-1
+      │   └── sub-prod-2
+      └── QA  [qa-mg]
+          └── sub-qa-1
+
+  Tip: set azure.rootMg in config.json to the name in brackets to scope connector creation.
+```
+
+The name in `[brackets]` is what you put in `azure.rootMg`.
+
+---
+
+### `delete`
+
+Permanently deletes one or more Qualys connectors by ID. This cannot be undone.
+
+```bash
+python main.py delete --ids <ID> [<ID> ...]
+```
+
+**Example:**
+
+```bash
+python main.py delete --ids 657901 657902
+```
+
+**Sample output:**
+
+```
+  Deleting 2 connector(s) …
+
+  ✓  [657901]  deleted
+  ✓  [657902]  deleted
+
+  Summary: 2 deleted, 0 failed
+```
+
+---
+
+### `restore-orphans`
+
+Re-enables connectors that were previously disabled by this script (via `disableOrphans`) if their Azure subscription is now active again in the current scope.
+
+```bash
+python main.py restore-orphans
+```
+
+This reads `connector_orphans_*.csv` history, discovers the current active Azure subscriptions, and re-enables any connector whose subscription is now back in scope. See [Orphan Detection](#orphan-detection) for the full explanation.
+
+---
+
+## Orphan Detection
+
+### What is an orphan?
+
+An orphan is a Qualys connector whose Azure subscription is **no longer in scope** — because the subscription was deleted, moved out of the managed Management Group, or you narrowed `azure.rootMg` in your config.
+
+Without cleanup, orphaned connectors keep running sync jobs in Qualys against subscriptions that are no longer managed, consuming resources and polluting your asset inventory.
+
+### How it works
+
+Enable with `"disableOrphans": true` in config. On every `create` run, **before** creating new connectors, the script:
+
+1. Reads all `connector_state_*.csv` files to identify the set of connectors **this script created** (by connector ID)
+2. Fetches the current list of connectors from Qualys
+3. Filters to only script-managed connectors (all others are untouched)
+4. Disables any script-managed connector whose subscription is not in the current Azure scope
+
+```
+Script-managed connector IDs (from CSV history)
+    ∩  connectors whose subscription is not in current Azure scope
+    ∩  connectors that are not already disabled
+    →  these are disabled
+```
+
+### What it does NOT touch
+
+- Connectors created outside this script (e.g. manually, by another tool)
+- Connectors that are already disabled
+- Connectors in Qualys for other cloud types (AWS, GCP)
+
+### Safety guard
+
+If no `connector_state_*.csv` history exists (first run on a new machine, or files were deleted), orphan detection **skips entirely** with a warning:
+
+```
+WARNING: Orphan detection requested but no CSV history found.
+Skipping to avoid touching connectors created outside this script.
+Run 'create' at least once so the script has a baseline.
+```
+
+This prevents the script from accidentally disabling connectors it didn't create.
+
+### Restoring orphans
+
+If a subscription comes back (or you expand `rootMg`), restore its connector:
+
+```bash
+python main.py restore-orphans
+```
+
+The script cross-references the `connector_orphans_*.csv` disable history against the current active Azure subscriptions and re-enables matching connectors. A `connector_restore_*.csv` is written with the results.
+
+### Example walkthrough
+
+```
+Step 1: rootMg = null (entire tenant, 5 subscriptions)
+        → create runs: connectors A B C D E created
+
+Step 2: rootMg = "QA"  (2 subscriptions: D, E)
+        disableOrphans = true
+        → create runs:
+            orphan check: A, B, C are no longer in scope → DISABLED
+            D, E already exist → skipped
+        → connector_orphans_<ts>.csv written
+
+Step 3: rootMg = null (5 subscriptions again)
+        → restore-orphans:
+            reads orphan CSV: A, B, C were disabled
+            checks Azure: A, B, C subscriptions are active again
+            → A, B, C RE-ENABLED
+        → connector_restore_<ts>.csv written
+```
+
+---
+
+## Output Files
+
+All files are written to `--output-dir` (default: current directory). Logs go in `<output-dir>/logs/`.
+
+| File | Created by | Contents |
+|---|---|---|
+| `connector_state_<ts>.csv` | `create` | Full record of every subscription processed: connector ID, status, and live state snapshot (connectorState, lastSyncedOn, asset counts) |
+| `connector_orphans_<ts>.csv` | `create` (with disableOrphans) | Record of connectors disabled by orphan detection |
+| `connector_restore_<ts>.csv` | `restore-orphans` | Record of connectors re-enabled |
+| `connector_delete_<ts>.csv` | `delete` | Audit log of manual deletions |
+| `logs/run_<ts>.log` | all commands | Full timestamped log of every API call and decision |
+
+### `connector_state_*.csv` columns
+
+| Column | Description |
+|---|---|
+| `timestamp` | UTC time of the run |
+| `tenant_id` | Azure tenant ID |
+| `app_type` | `cspm` or `asset-inventory` |
+| `dry_run` | `true` or `false` |
+| `subscription_id` | Azure subscription ID |
+| `subscription_name` | Subscription display name |
+| `management_group` | Parent MG name |
+| `connector_name` | Name given to the Qualys connector |
+| `connector_id` | Qualys connector ID |
+| `status` | `created`, `skipped`, `failed`, or `dry_run` |
+| `note` | Error message (if failed) or `already_exists` (if skipped) |
+| `connector_state` | Live state from Qualys (e.g. `FINISHED_SUCCESS`) |
+| `last_synced_on` | Timestamp of last successful sync |
+| `total_assets_created` | Assets added in last sync |
+| `total_assets_updated` | Assets updated in last sync |
+| `total_assets_deleted` | Assets removed in last sync |
+| `connector_error` | Error detail from Qualys (if any) |
+| `disabled` | Whether the connector is disabled in Qualys |
+| `run_frequency` | Configured sync interval (minutes) |
+
+---
+
+## Security Notes
+
+| Topic | Guidance |
+|---|---|
+| `config.json` | Contains Azure SP secret and Qualys credentials. Never commit to version control. The script warns at startup if the file is not gitignored. |
+| SP Secret rotation | The SP secret is stored as `authenticationKey` inside each Qualys connector's `authRecord`. If you rotate the secret, update `config.json` **and** update existing connectors in Qualys (or delete and re-create them). |
+| Qualys credentials | Transmitted over HTTPS (Basic Auth). Use a Qualys service account with the minimum role needed to manage connectors. |
+| Least privilege | The Azure SP only needs read access to Management Groups and Subscriptions — no write access to Azure resources. |
+| Output files | `connector_state_*.csv` files contain subscription IDs and connector IDs but no secrets. They are safe to retain for audit purposes. |
+
+---
+
+## Project Structure
+
+```
+azure-gov-tenant-connector/
+├── main.py              # CLI entry point — all commands, config loading, CSV output
+├── azure_client.py      # Azure MG/subscription discovery (Gov + Commercial)
+├── qualys_client.py     # Qualys Connectors API client (create, search, update, delete)
+├── config.json          # Your credentials and settings (gitignored)
+├── config.example.json  # Full schema reference with all fields and defaults
+├── requirements.txt     # Python dependencies
+├── .gitignore           # Excludes config.json, CSVs, logs, .venv
+├── logs/                # Per-run log files
+├── connector_state_*.csv
+├── connector_orphans_*.csv
+├── connector_restore_*.csv
+└── connector_delete_*.csv
+```
+
+---
+
+## Frequently Asked Questions
+
+**What happens if I run `create` twice?**
+
+Nothing bad. The script checks whether a connector already exists for each subscription before creating one. Duplicates are skipped and reported as `Already existed` in the summary. It is safe to run on a schedule.
+
+**Can I use a different config file per environment?**
+
+Yes. Use `--config`:
+
+```bash
+python main.py --config config-gov-prod.json create
+python main.py --config config-commercial-dev.json create
+```
+
+**Can I scope to a specific MG without changing the config?**
+
+No — the scope is controlled by `azure.rootMg` in the config file. Use separate config files for different scopes.
+
+**What if a subscription has no display name?**
+
+The connector name falls back to `azure-sub-<subscription-id>`.
+
+**What is the connector name length limit?**
+
+Qualys enforces a 255-character limit. The script automatically truncates names that exceed this.
+
+**My run was interrupted mid-way. What do I do?**
+
+Re-run `create`. Connectors already created will be skipped (idempotent). The run will pick up where it left off effectively.
+
+**I deleted `connector_state_*.csv` files. Will orphan detection break?**
+
+It will skip orphan detection and print a warning (the safety guard). Run `create` once normally to rebuild the history, then orphan detection will work on the next run.

--- a/Connectors/Azure/AzureTenantConnector/azure_client.py
+++ b/Connectors/Azure/AzureTenantConnector/azure_client.py
@@ -1,0 +1,226 @@
+"""
+Azure client — discovers tenant, management groups, and subscriptions.
+Supports both Azure Government and Azure Commercial clouds, selected via is_gov_cloud.
+"""
+
+import logging
+from typing import Optional
+
+from azure.identity import ClientSecretCredential, AzureAuthorityHosts
+from azure.mgmt.managementgroups import ManagementGroupsAPI
+from azure.mgmt.subscription import SubscriptionClient
+from azure.core.exceptions import HttpResponseError
+
+log = logging.getLogger(__name__)
+
+_GOV_ARM        = "https://management.usgovcloudapi.net"
+_GOV_AUTH       = AzureAuthorityHosts.AZURE_GOVERNMENT   # login.microsoftonline.us
+
+_COMMERCIAL_ARM  = "https://management.azure.com"
+_COMMERCIAL_AUTH = AzureAuthorityHosts.AZURE_PUBLIC_CLOUD  # login.microsoftonline.com
+
+
+def _endpoints(is_gov_cloud: bool) -> tuple[str, str]:
+    """Return (arm_endpoint, authority_host) for the chosen cloud."""
+    if is_gov_cloud:
+        return _GOV_ARM, _GOV_AUTH
+    return _COMMERCIAL_ARM, _COMMERCIAL_AUTH
+
+
+def build_credential(
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    is_gov_cloud: bool = True,
+) -> ClientSecretCredential:
+    _, authority = _endpoints(is_gov_cloud)
+    return ClientSecretCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        authority=authority,
+    )
+
+
+def get_tenant_info(credential: ClientSecretCredential, tenant_id: str, is_gov_cloud: bool = True) -> dict:
+    arm, _ = _endpoints(is_gov_cloud)
+    return {
+        "tenantId":    tenant_id,
+        "cloud":       "AzureUSGovernment" if is_gov_cloud else "AzureCommercial",
+        "armEndpoint": arm,
+    }
+
+
+def _mg_client(credential: ClientSecretCredential, is_gov_cloud: bool = True) -> ManagementGroupsAPI:
+    arm, _ = _endpoints(is_gov_cloud)
+    return ManagementGroupsAPI(
+        credential,
+        base_url=arm,
+        credential_scopes=[f"{arm}/.default"],
+    )
+
+
+def list_management_groups(
+    credential: ClientSecretCredential,
+    is_gov_cloud: bool = True,
+) -> list[dict]:
+    """Return all management groups the SP can see as a flat list."""
+    groups = []
+    try:
+        for mg in _mg_client(credential, is_gov_cloud).management_groups.list():
+            groups.append({
+                "id":          mg.id,
+                "name":        mg.name,
+                "displayName": mg.display_name,
+                "type":        mg.type,
+                "parentName":  None,
+            })
+    except HttpResponseError as exc:
+        log.warning("Management Groups API error: %s", exc)
+    return groups
+
+
+def get_mg_hierarchy(
+    credential: ClientSecretCredential,
+    mg_name: str,
+    depth: int = 0,
+    is_gov_cloud: bool = True,
+) -> dict:
+    """
+    Recursively fetch the management group tree rooted at mg_name.
+    Returns a dict with keys: name, displayName, children, depth.
+    """
+    client = _mg_client(credential, is_gov_cloud)
+    try:
+        detail = client.management_groups.get(
+            group_id=mg_name,
+            expand="children",
+            recurse=True,
+        )
+    except HttpResponseError as exc:
+        log.warning("Could not fetch MG details for %s: %s", mg_name, exc)
+        return {"name": mg_name, "displayName": mg_name, "children": [], "depth": depth}
+
+    def _walk(node, d: int) -> dict:
+        children = []
+        for child in (getattr(node, "children", None) or []):
+            child_type = getattr(child, "type", "")
+            if "managementGroups" in child_type:
+                children.append(_walk(child, d + 1))
+        return {
+            "name":        node.name,
+            "displayName": getattr(node, "display_name", node.name),
+            "children":    children,
+            "depth":       d,
+        }
+
+    return _walk(detail, depth)
+
+
+def _collect_mg_names(hierarchy: dict) -> list[str]:
+    """Flatten a hierarchy dict into a list of all MG names (including root)."""
+    names = [hierarchy["name"]]
+    for child in hierarchy.get("children", []):
+        names.extend(_collect_mg_names(child))
+    return names
+
+
+def list_subscriptions_in_management_group(
+    credential: ClientSecretCredential,
+    management_group_name: str,
+    is_gov_cloud: bool = True,
+) -> list[dict]:
+    """Return all subscriptions under the given management group."""
+    subscriptions = []
+    try:
+        for entity in _mg_client(credential, is_gov_cloud).management_group_subscriptions.get_subscriptions_under_management_group(
+            group_id=management_group_name
+        ):
+            subscriptions.append({
+                "subscriptionId":      entity.name,
+                "displayName":         entity.display_name,
+                "managementGroupName": management_group_name,
+                "state":               getattr(entity, "state", "Unknown"),
+            })
+    except (HttpResponseError, AttributeError) as exc:
+        log.warning("Could not list subscriptions under MG %s: %s", management_group_name, exc)
+    return subscriptions
+
+
+def list_all_subscriptions(
+    credential: ClientSecretCredential,
+    is_gov_cloud: bool = True,
+) -> list[dict]:
+    """Fallback: all subscriptions visible via the Subscriptions API."""
+    arm, _ = _endpoints(is_gov_cloud)
+    client = SubscriptionClient(
+        credential,
+        base_url=arm,
+        credential_scopes=[f"{arm}/.default"],
+    )
+    subs = []
+    for sub in client.subscriptions.list():
+        state = sub.state
+        subs.append({
+            "subscriptionId":      sub.subscription_id,
+            "displayName":         sub.display_name,
+            "state":               (state.value if hasattr(state, "value") else str(state)) if state else "Unknown",
+            "managementGroupName": None,
+        })
+    return subs
+
+
+def discover_subscriptions(
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    root_management_group: Optional[str] = None,
+    is_gov_cloud: bool = True,
+) -> tuple[dict, list[dict], list[dict]]:
+    """
+    Main discovery entry point. Works for both Azure Government and Commercial.
+
+    If root_management_group is given, fetches that MG's full descendant tree
+    (all child/grandchild MGs) and collects subscriptions from every node.
+
+    Returns:
+        (tenant_info, management_groups, active_subscriptions)
+    """
+    credential  = build_credential(tenant_id, client_id, client_secret, is_gov_cloud)
+    tenant_info = get_tenant_info(credential, tenant_id, is_gov_cloud)
+
+    cloud_label = "Government" if is_gov_cloud else "Commercial"
+    log.info("Cloud         : Azure %s", cloud_label)
+    log.info("Listing management groups for tenant %s …", tenant_id)
+    all_mgs = list_management_groups(credential, is_gov_cloud)
+    log.info("Found %d management group(s)", len(all_mgs))
+
+    subscriptions: list[dict] = []
+    seen_ids: set[str] = set()
+
+    if all_mgs:
+        if root_management_group:
+            log.info("Building MG hierarchy under '%s' …", root_management_group)
+            hierarchy = get_mg_hierarchy(credential, root_management_group, is_gov_cloud=is_gov_cloud)
+            target_mg_names = _collect_mg_names(hierarchy)
+            log.info("Scoping to %d MG(s): %s", len(target_mg_names), target_mg_names)
+        else:
+            target_mg_names = [mg["name"] for mg in all_mgs]
+
+        for mg_name in target_mg_names:
+            log.info("Enumerating subscriptions under management group '%s' …", mg_name)
+            for sub in list_subscriptions_in_management_group(credential, mg_name, is_gov_cloud):
+                if sub["subscriptionId"] not in seen_ids:
+                    subscriptions.append(sub)
+                    seen_ids.add(sub["subscriptionId"])
+
+    if not subscriptions:
+        log.info("Falling back to subscription-list API …")
+        for sub in list_all_subscriptions(credential, is_gov_cloud):
+            if sub["subscriptionId"] not in seen_ids:
+                subscriptions.append(sub)
+                seen_ids.add(sub["subscriptionId"])
+
+    active = [s for s in subscriptions if s.get("state", "").lower() in ("enabled", "active", "unknown")]
+    log.info("Discovered %d subscription(s) (%d active)", len(subscriptions), len(active))
+    return tenant_info, all_mgs, active

--- a/Connectors/Azure/AzureTenantConnector/config.example.json
+++ b/Connectors/Azure/AzureTenantConnector/config.example.json
@@ -1,0 +1,24 @@
+{
+  "azure": {
+    "tenantId":     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId":     "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientSecret": "your-sp-client-secret",
+    "rootMg":       null
+  },
+
+  "qualys": {
+    "username":       "your-qualys-username",
+    "password":       "your-qualys-password",
+
+    "platform":       "US2",
+
+    "appType":        "cspm",
+    "activation":     ["VM", "PC"],
+    "runFrequency":   1440,
+    "isGovCloud":     false,
+    "disableOrphans": false,
+
+    "connectorTags":  ["azure-commercial", "production"],
+    "assetTags":      ["azure-asset", "cloud-discovery"]
+  }
+}

--- a/Connectors/Azure/AzureTenantConnector/main.py
+++ b/Connectors/Azure/AzureTenantConnector/main.py
@@ -1,0 +1,770 @@
+#!/usr/bin/env python3
+"""
+Azure → Qualys Tenant Connector
+
+Sub-commands:
+  create          Discover subscriptions and create a Qualys connector per subscription
+  list            List all Azure connectors currently in Qualys
+  status          Show live state for specific connector ID(s)
+  list-mgs        Show management group hierarchy (to choose azure.rootMg in config)
+  delete          Delete one or more Qualys connectors by ID
+  restore-orphans Re-enable connectors that were previously disabled by this script
+
+All run settings live in config.json. Only --config FILE and subcommand flags are CLI args.
+See config.example.json for the full schema.
+"""
+
+import argparse
+import csv
+import json
+import logging
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from azure_client import (
+    build_credential,
+    discover_subscriptions,
+    get_mg_hierarchy,
+    list_management_groups,
+)
+from qualys_client import (
+    APP_TYPE_CONFIG,
+    ConnectorResult,
+    QualysClient,
+    VALID_ACTIVATION_MODULES,
+    resolve_connector_name,
+    resolve_platform_url,
+)
+
+_LOG_FMT  = "%(asctime)s  %(levelname)-7s  %(message)s"
+_LOG_DATE = "%Y-%m-%d %H:%M:%S"
+
+_APP_TYPE_MAP = {
+    "asset-inventory": "AI",
+    "cspm":            "CSA",
+}
+
+_DELETE_PATH = "/qps/rest/3.0/delete/am/azureassetdataconnector"
+
+
+# ── logging ───────────────────────────────────────────────────────────────────
+
+def _setup_logging(output_dir: Path) -> Path:
+    log_dir = output_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"run_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}.log"
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    console = logging.StreamHandler(sys.stdout)
+    console.setFormatter(logging.Formatter(_LOG_FMT, datefmt="%H:%M:%S"))
+    root.addHandler(console)
+
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setFormatter(logging.Formatter(_LOG_FMT, datefmt=_LOG_DATE))
+    root.addHandler(fh)
+
+    # Silence chatty Azure SDK HTTP transport logs
+    for noisy in ("azure.core.pipeline.policies.http_logging_policy",
+                  "azure.identity", "urllib3"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    return log_path
+
+
+log = logging.getLogger(__name__)
+
+
+# ── config loading ────────────────────────────────────────────────────────────
+
+def _check_config_gitignored(config_path: str) -> None:
+    """Warn if config.json is not gitignored (it contains credentials)."""
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", config_path],
+            capture_output=True, timeout=3,
+        )
+        if result.returncode == 1:
+            # returncode 0 = ignored, 1 = not ignored, 128 = not in a git repo
+            log.warning(
+                "SECURITY WARNING: %s is NOT gitignored — it contains credentials. "
+                "Add it to .gitignore before committing.",
+                config_path,
+            )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass  # git not available
+
+
+def load_config(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        log.error("Config file not found: %s", path)
+        log.error("Copy config.example.json → config.json and fill in your values.")
+        sys.exit(1)
+    with p.open() as fh:
+        try:
+            cfg = json.load(fh)
+        except json.JSONDecodeError as exc:
+            log.error("Invalid JSON in %s: %s", path, exc)
+            sys.exit(1)
+    for section in ("azure", "qualys"):
+        if section not in cfg:
+            log.error("Config missing required section '%s'", section)
+            sys.exit(1)
+    _check_config_gitignored(path)
+    return cfg
+
+
+def _azure_creds(cfg: dict) -> tuple[str, str, str]:
+    az = cfg["azure"]
+    missing = [k for k in ("tenantId", "clientId", "clientSecret") if not az.get(k)]
+    if missing:
+        log.error("Config azure section missing required keys: %s", missing)
+        sys.exit(1)
+    return az["tenantId"], az["clientId"], az["clientSecret"]
+
+
+def _qualys_settings(cfg: dict) -> dict:
+    q = cfg["qualys"]
+    missing = [k for k in ("username", "password") if not q.get(k)]
+    if missing:
+        log.error("Config qualys section missing required keys: %s", missing)
+        sys.exit(1)
+
+    platform_val = q.get("platform") or q.get("baseUrl") or "US2"
+    try:
+        base_url = resolve_platform_url(platform_val)
+    except ValueError as exc:
+        log.error("%s", exc)
+        sys.exit(1)
+
+    raw_app_type = q.get("appType", "cspm").lower()
+    if raw_app_type not in _APP_TYPE_MAP:
+        log.error("Config qualys.appType must be one of: %s", list(_APP_TYPE_MAP))
+        sys.exit(1)
+
+    activation = q.get("activation") or []
+    invalid = [m for m in activation if m not in VALID_ACTIVATION_MODULES]
+    if invalid:
+        log.error(
+            "Config qualys.activation contains unknown module(s): %s  (valid: %s)",
+            invalid, VALID_ACTIVATION_MODULES,
+        )
+        sys.exit(1)
+
+    if "PC" in activation and "SCA" in activation:
+        log.error("Config qualys.activation: PC and SCA cannot be activated together — choose one.")
+        sys.exit(1)
+
+    run_frequency = int(q.get("runFrequency", 1440))
+    if run_frequency < 1:
+        log.error("Config qualys.runFrequency must be >= 1 minute")
+        sys.exit(1)
+
+    return {
+        "username":        q["username"],
+        "password":        q["password"],
+        "base_url":        base_url,
+        "platform_label":  platform_val.upper() if not platform_val.startswith("http") else "custom",
+        "app_type_label":  raw_app_type,
+        "app_type_key":    _APP_TYPE_MAP[raw_app_type],
+        "activation":      activation,
+        "run_frequency":   run_frequency,
+        "is_gov_cloud":    bool(q.get("isGovCloud", True)),
+        "disable_orphans": bool(q.get("disableOrphans", False)),
+        "connector_tags":  q.get("connectorTags") or [],
+        "asset_tags":      q.get("assetTags") or [],
+    }
+
+
+def _qualys_client(qs: dict) -> QualysClient:
+    return QualysClient(
+        username=qs["username"],
+        password=qs["password"],
+        base_url=qs["base_url"],
+    )
+
+
+# ── CSV / summary ─────────────────────────────────────────────────────────────
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _save_csv(
+    results: list[ConnectorResult],
+    tenant_id: str,
+    app_type_label: str,
+    dry_run: bool,
+    output_dir: Path,
+    states: Optional[dict[str, dict]] = None,
+) -> Path:
+    filename = output_dir / f"connector_state_{_ts()}.csv"
+    fieldnames = [
+        "timestamp", "tenant_id", "app_type", "dry_run",
+        "subscription_id", "subscription_name", "management_group",
+        "connector_name", "connector_id", "status", "note",
+        "connector_state", "last_synced_on",
+        "total_assets_created", "total_assets_updated", "total_assets_deleted",
+        "connector_error", "disabled", "run_frequency",
+    ]
+    now = datetime.now(timezone.utc).isoformat()
+    states = states or {}
+    with open(filename, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in results:
+            st = states.get(r.connector_id or "", {})
+            writer.writerow({
+                "timestamp":            now,
+                "tenant_id":            tenant_id,
+                "app_type":             app_type_label,
+                "dry_run":              str(dry_run).lower(),
+                "subscription_id":      r.subscription_id,
+                "subscription_name":    r.subscription_name,
+                "management_group":     r.management_group,
+                "connector_name":       r.connector_name,
+                "connector_id":         r.connector_id or "",
+                "status":               r.status,
+                "note":                 r.note or "",
+                "connector_state":      st.get("connector_state", ""),
+                "last_synced_on":       st.get("last_synced_on", ""),
+                "total_assets_created": st.get("total_assets_created", ""),
+                "total_assets_updated": st.get("total_assets_updated", ""),
+                "total_assets_deleted": st.get("total_assets_deleted", ""),
+                "connector_error":      st.get("connector_error", ""),
+                "disabled":             st.get("disabled", ""),
+                "run_frequency":        st.get("run_frequency", ""),
+            })
+    return filename
+
+
+def _save_orphan_csv(orphans: list[dict], output_dir: Path) -> Path:
+    filename = output_dir / f"connector_orphans_{_ts()}.csv"
+    fieldnames = ["timestamp", "connector_id", "connector_name", "subscription_id", "result", "note"]
+    now = datetime.now(timezone.utc).isoformat()
+    with open(filename, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for o in orphans:
+            writer.writerow({
+                "timestamp":       now,
+                "connector_id":    o["id"],
+                "connector_name":  o["name"],
+                "subscription_id": o["subscriptionId"],
+                "result":          o["result"],
+                "note":            o.get("note", ""),
+            })
+    return filename
+
+
+def _print_summary(results: list[ConnectorResult]) -> None:
+    created = [r for r in results if r.status == "created"]
+    skipped = [r for r in results if r.status == "skipped"]
+    dry     = [r for r in results if r.status == "dry_run"]
+    failed  = [r for r in results if r.status == "failed"]
+
+    print("\n" + "=" * 65)
+    print(f"  Summary — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    print("=" * 65)
+    print(f"  Total          : {len(results)}")
+    if dry:
+        print(f"  Dry-run (enum) : {len(dry)}")
+    else:
+        print(f"  Created        : {len(created)}")
+        print(f"  Already existed: {len(skipped)}")
+        print(f"  Failed         : {len(failed)}")
+
+    for label, bucket, icon in [
+        ("Created", created, "✓"),
+        ("Skipped", skipped, "↷"),
+        ("Dry-run", dry,     "○"),
+        ("Failed",  failed,  "✗"),
+    ]:
+        if bucket:
+            print(f"\n  {label}:")
+            for r in bucket:
+                cid = f"[{r.connector_id}] " if r.connector_id else ""
+                err = f"  — {r.note}" if r.note and r.status == "failed" else ""
+                print(f"    {icon} {cid}{r.connector_name} ({r.subscription_id}){err}")
+    print("=" * 65)
+
+
+# ── CSV history ───────────────────────────────────────────────────────────────
+
+def _scan_state_csvs(*dirs: Path) -> set[str]:
+    """
+    Scan connector_state_*.csv files in the given directories.
+    Returns the set of connector IDs with status=='created'.
+    """
+    managed: set[str] = set()
+    seen_files: set[Path] = set()
+    for d in dirs:
+        for path in sorted(d.glob("connector_state_*.csv")):
+            if path in seen_files:
+                continue
+            seen_files.add(path)
+            try:
+                with path.open(newline="") as fh:
+                    for row in csv.DictReader(fh):
+                        if row.get("status") == "created" and row.get("connector_id"):
+                            managed.add(row["connector_id"])
+            except Exception as exc:
+                log.warning("Could not read CSV %s: %s", path, exc)
+    log.info("CSV history: %d script-managed connector ID(s) found across %d file(s)",
+             len(managed), len(seen_files))
+    return managed
+
+
+def _load_managed_connector_ids(output_dir: Path) -> set[str]:
+    """Collect previously created connector IDs from all known CSV locations."""
+    dirs = {output_dir, Path(".")}
+    return _scan_state_csvs(*dirs)
+
+
+def _load_disabled_connectors(output_dir: Path) -> dict[str, str]:
+    """
+    Read connector_orphans_*.csv files and return {connector_id: subscription_id}
+    for connectors that were disabled by this script (result == 'disabled').
+    """
+    result: dict[str, str] = {}
+    seen: set[Path] = set()
+    for d in {output_dir, Path(".")}:
+        for path in sorted(d.glob("connector_orphans_*.csv")):
+            if path in seen:
+                continue
+            seen.add(path)
+            try:
+                with path.open(newline="") as fh:
+                    for row in csv.DictReader(fh):
+                        if row.get("result") == "disabled" and row.get("connector_id"):
+                            result[row["connector_id"]] = row.get("subscription_id", "")
+            except Exception as exc:
+                log.warning("Could not read orphan CSV %s: %s", path, exc)
+    log.info("Orphan CSV history: %d previously disabled connector(s) found", len(result))
+    return result
+
+
+# ── create ────────────────────────────────────────────────────────────────────
+
+def cmd_create(args: argparse.Namespace) -> int:
+    cfg = load_config(args.config)
+    qs  = _qualys_settings(cfg)
+    dry_run    = args.dry_run
+    parallel   = args.parallel
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tenant_id, client_id, client_secret = _azure_creds(cfg)
+    root_mg = cfg["azure"].get("rootMg") or None
+
+    app_modules = APP_TYPE_CONFIG.get(qs["app_type_key"], APP_TYPE_CONFIG["CSA"])
+
+    log.info("=" * 60)
+    log.info("Azure Tenant Connector")
+    log.info("Tenant        : %s", tenant_id)
+    log.info("SP            : %s", client_id)
+    log.info("Qualys        : %s  (%s)", qs["platform_label"], qs["base_url"])
+    log.info("App-type      : %s  →  appInfos=%s", qs["app_type_label"], app_modules)
+    log.info("Activation    : %s", qs["activation"] if qs["activation"] else "(none)")
+    log.info("Run frequency : %d min", qs["run_frequency"])
+    log.info("Gov cloud     : %s", qs["is_gov_cloud"])
+    log.info("Scope         : %s", f"MG '{root_mg}' (+ children)" if root_mg else "entire tenant")
+    log.info("Orphan check  : %s", qs["disable_orphans"])
+    log.info("Connector tags: %s", qs["connector_tags"] or "(none)")
+    log.info("Asset tags    : %s", qs["asset_tags"] or "(none)")
+    log.info("Parallel      : %d", parallel)
+    log.info("Output dir    : %s", output_dir.resolve())
+    log.info("Mode          : %s", "DRY RUN" if dry_run else "LIVE")
+    log.info("=" * 60)
+
+    tenant_info, management_groups, subscriptions = discover_subscriptions(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        root_management_group=root_mg,
+        is_gov_cloud=qs["is_gov_cloud"],
+    )
+
+    log.info("MGs found            : %d", len(management_groups))
+    log.info("Active subscriptions : %d", len(subscriptions))
+
+    if not subscriptions:
+        log.warning("No active subscriptions found. Check SP permissions or azure.rootMg in config.")
+        return 0
+
+    print(f"\n  {'#':<4} {'Subscription ID':<38} {'Connector Name':<42} MG")
+    print("  " + "-" * 105)
+    for idx, sub in enumerate(subscriptions, 1):
+        sub_id = sub["subscriptionId"]
+        name   = resolve_connector_name(sub.get("displayName"), sub_id)
+        mg     = sub.get("managementGroupName", "")
+        print(f"  {idx:<4} {sub_id:<38} {name:<42} {mg}")
+    print()
+
+    if dry_run:
+        results = [
+            ConnectorResult(
+                subscription_id=sub["subscriptionId"],
+                subscription_name=sub.get("displayName", sub["subscriptionId"]),
+                connector_name=resolve_connector_name(sub.get("displayName"), sub["subscriptionId"]),
+                management_group=sub.get("managementGroupName", ""),
+                success=True,
+                status="dry_run",
+            )
+            for sub in subscriptions
+        ]
+        _print_summary(results)
+        csv_path = _save_csv(results, tenant_id, qs["app_type_label"], dry_run=True, output_dir=output_dir)
+        log.info("DRY RUN — CSV saved: %s", csv_path)
+        return 0
+
+    client = _qualys_client(qs)
+
+    connector_tag_ids: list[int] = []
+    asset_tag_ids: list[int] = []
+    if qs["connector_tags"]:
+        connector_tag_ids = client.resolve_tag_names(qs["connector_tags"])
+    if qs["asset_tags"]:
+        asset_tag_ids = client.resolve_tag_names(qs["asset_tags"])
+
+    # Drift detection — scoped strictly to connectors this script previously created
+    if qs["disable_orphans"]:
+        managed_ids = _load_managed_connector_ids(output_dir)
+        if not managed_ids:
+            log.warning(
+                "Orphan detection requested (disableOrphans=true) but no CSV history found. "
+                "Skipping to avoid touching connectors created outside this script. "
+                "Run 'create' at least once so the script has a baseline."
+            )
+        else:
+            active_sub_ids = {sub["subscriptionId"] for sub in subscriptions}
+            log.info("Drift check — disabling script-managed connectors for subscriptions no longer in scope …")
+            orphans = client.disable_orphan_connectors(active_sub_ids, managed_connector_ids=managed_ids)
+            if orphans:
+                orphan_csv = _save_orphan_csv(orphans, output_dir)
+                dis  = sum(1 for o in orphans if o["result"] == "disabled")
+                fail = len(orphans) - dis
+                log.info("Orphans: %d disabled, %d failed  →  %s", dis, fail, orphan_csv)
+                print("\n  Orphan connectors (subscription no longer active):")
+                for o in orphans:
+                    icon = "✓" if o["result"] == "disabled" else "✗"
+                    print(f"    {icon} [{o['id']}] {o['name']} (sub={o['subscriptionId']}) — {o['result']}")
+
+    results = client.create_connectors_bulk(
+        subscriptions=subscriptions,
+        directory_id=tenant_id,
+        application_id=client_id,
+        authentication_key=client_secret,
+        is_gov_cloud=qs["is_gov_cloud"],
+        app_type=qs["app_type_key"],
+        activation_modules=qs["activation"],
+        run_frequency=qs["run_frequency"],
+        connector_tag_ids=connector_tag_ids,
+        asset_tag_ids=asset_tag_ids,
+        parallel=parallel,
+    )
+
+    _print_summary(results)
+
+    states: dict[str, dict] = {}
+    ids_to_fetch = [r.connector_id for r in results if r.connector_id]
+    if ids_to_fetch:
+        log.info("Fetching live connector state for %d connector(s) …", len(ids_to_fetch))
+        for cid in ids_to_fetch:
+            st = client.get_connector_state(cid)
+            if st:
+                states[cid] = st
+                log.info("  [%s] state=%s  lastSync=%s  assets_created=%s",
+                         cid,
+                         st.get("connector_state", "?"),
+                         st.get("last_synced_on", "?"),
+                         st.get("total_assets_created", "?"))
+
+    csv_path = _save_csv(results, tenant_id, qs["app_type_label"], dry_run=False,
+                         output_dir=output_dir, states=states)
+    log.info("State CSV saved: %s", csv_path)
+    return 1 if any(r.status == "failed" for r in results) else 0
+
+
+# ── list ──────────────────────────────────────────────────────────────────────
+
+def cmd_list(args: argparse.Namespace) -> int:
+    cfg    = load_config(args.config)
+    qs     = _qualys_settings(cfg)
+    client = _qualys_client(qs)
+
+    log.info("Qualys platform: %s  (%s)", qs["platform_label"], qs["base_url"])
+    connectors = client.list_all_connectors()
+
+    if not connectors:
+        print("  No Azure connectors found.")
+        return 0
+
+    if args.subscription:
+        connectors = [c for c in connectors if args.subscription in c["subscriptionId"]]
+        log.info("Filtered to subscription containing '%s': %d result(s)", args.subscription, len(connectors))
+
+    print(f"\n  {'ID':<10} {'Name':<46} {'Subscription ID':<38} {'State':<14} Disabled")
+    print("  " + "-" * 120)
+    for c in connectors:
+        name = c["name"][:45]
+        print(f"  {c['id']:<10} {name:<46} {c['subscriptionId']:<38} "
+              f"{c.get('connectorState',''):<14} {str(c['disabled']).lower()}")
+    print(f"\n  Total: {len(connectors)} connector(s)")
+    return 0
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+def cmd_status(args: argparse.Namespace) -> int:
+    cfg    = load_config(args.config)
+    qs     = _qualys_settings(cfg)
+    client = _qualys_client(qs)
+
+    log.info("Qualys platform: %s  (%s)", qs["platform_label"], qs["base_url"])
+    for cid in args.ids:
+        st = client.get_connector_state(cid)
+        if not st:
+            print(f"\n  [{cid}] Not found or error.")
+            continue
+        print(f"\n  Connector {cid}:")
+        print(f"    State          : {st.get('connector_state','')}")
+        print(f"    Last Synced    : {st.get('last_synced_on','')}")
+        print(f"    Assets Created : {st.get('total_assets_created','')}")
+        print(f"    Assets Updated : {st.get('total_assets_updated','')}")
+        print(f"    Assets Deleted : {st.get('total_assets_deleted','')}")
+        err = st.get("connector_error", "")
+        print(f"    Error          : {err or '(none)'}")
+        print(f"    Disabled       : {st.get('disabled','')}")
+        print(f"    Run Frequency  : {st.get('run_frequency','')} min")
+    return 0
+
+
+# ── list-mgs ──────────────────────────────────────────────────────────────────
+
+def cmd_list_mgs(args: argparse.Namespace) -> int:
+    cfg = load_config(args.config)
+    tenant_id, client_id, client_secret = _azure_creds(cfg)
+
+    is_gov_cloud = bool(cfg["qualys"].get("isGovCloud", True))
+    credential   = build_credential(tenant_id, client_id, client_secret, is_gov_cloud)
+    all_mgs      = list_management_groups(credential, is_gov_cloud)
+
+    if not all_mgs:
+        log.warning("No management groups found. Check SP permissions.")
+        return 1
+
+    root_mg = all_mgs[0]["name"]
+    log.info("Fetching MG hierarchy from root '%s' …", root_mg)
+    hierarchy = get_mg_hierarchy(credential, root_mg, is_gov_cloud=is_gov_cloud)
+
+    def _print_tree(node: dict, prefix: str = "", is_last: bool = True) -> None:
+        ch    = "└── " if is_last else "├── "
+        disp  = node["displayName"]
+        name  = node["name"]
+        label = f"{disp}  [{name}]" if disp != name else f"[{name}]"
+        print(f"  {prefix}{ch}{label}")
+        children     = node.get("children", [])
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        for i, child in enumerate(children):
+            _print_tree(child, child_prefix, is_last=(i == len(children) - 1))
+
+    print(f"\n  Management Group hierarchy — tenant {tenant_id}:\n")
+    _print_tree(hierarchy)
+    print()
+    print('  Tip: set azure.rootMg in config.json to the name in brackets to scope connector creation.')
+    print()
+    return 0
+
+
+# ── delete ────────────────────────────────────────────────────────────────────
+
+def _delete_one(client: QualysClient, connector_id: str) -> tuple[bool, str]:
+    url = f"{client._base}{_DELETE_PATH}/{connector_id}"
+    log.info("Deleting connector id=%s", connector_id)
+    try:
+        resp = client._session.post(url, data=b"", auth=client._auth, timeout=30)
+        log.debug("  delete HTTP %d", resp.status_code)
+        root = ET.fromstring(resp.text)
+        if root.findtext("responseCode") == "SUCCESS":
+            log.info("  ✓ Connector %s deleted", connector_id)
+            return True, "deleted"
+        err = root.findtext("responseErrorDetails/errorMessage") or f"HTTP {resp.status_code}"
+        log.warning("  ✗ Failed to delete %s: %s", connector_id, err)
+        return False, err
+    except Exception as exc:
+        log.warning("  ✗ Exception deleting %s: %s", connector_id, exc)
+        return False, str(exc)
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    cfg    = load_config(args.config)
+    qs     = _qualys_settings(cfg)
+    client = _qualys_client(qs)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ids    = args.ids
+    total  = len(ids)
+    failed = 0
+
+    log.info("Qualys platform: %s  (%s)", qs["platform_label"], qs["base_url"])
+    print(f"\n  Deleting {total} connector(s) …\n")
+    rows = []
+    for cid in ids:
+        ok, msg = _delete_one(client, cid)
+        icon = "✓" if ok else "✗"
+        print(f"  {icon}  [{cid}]  {msg}")
+        rows.append({"connector_id": cid, "status": "deleted" if ok else "failed", "note": msg})
+        if not ok:
+            failed += 1
+
+    filename = output_dir / f"connector_delete_{_ts()}.csv"
+    with open(filename, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["timestamp", "connector_id", "status", "note"])
+        writer.writeheader()
+        now = datetime.now(timezone.utc).isoformat()
+        for row in rows:
+            writer.writerow({"timestamp": now, **row})
+
+    print(f"\n  Summary: {total - failed} deleted, {failed} failed")
+    log.info("Delete log saved: %s", filename)
+    return 1 if failed else 0
+
+
+# ── restore-orphans ───────────────────────────────────────────────────────────
+
+def cmd_restore_orphans(args: argparse.Namespace) -> int:
+    """
+    Re-enable connectors that were previously disabled by this script (tracked in
+    connector_orphans_*.csv) if their Azure subscription is now active again.
+    """
+    cfg = load_config(args.config)
+    qs  = _qualys_settings(cfg)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    disabled = _load_disabled_connectors(output_dir)
+    if not disabled:
+        log.info("No previously disabled connectors found in CSV history — nothing to restore.")
+        return 0
+
+    tenant_id, client_id, client_secret = _azure_creds(cfg)
+    root_mg = cfg["azure"].get("rootMg") or None
+
+    log.info("Discovering current active Azure subscriptions …")
+    _, _, subscriptions = discover_subscriptions(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        root_management_group=root_mg,
+        is_gov_cloud=qs["is_gov_cloud"],
+    )
+    active_sub_ids = {sub["subscriptionId"] for sub in subscriptions}
+
+    to_restore = {cid: sub_id for cid, sub_id in disabled.items() if sub_id in active_sub_ids}
+    if not to_restore:
+        log.info("None of the %d previously disabled connector(s) have subscriptions that are now active.",
+                 len(disabled))
+        return 0
+
+    log.info("Restoring %d connector(s) whose subscriptions are now active …", len(to_restore))
+    client = _qualys_client(qs)
+    print(f"\n  Restoring {len(to_restore)} connector(s) …\n")
+    rows = []
+    failed = 0
+    for cid, sub_id in to_restore.items():
+        ok, msg = client.enable_connector(cid)
+        icon = "✓" if ok else "✗"
+        print(f"  {icon}  [{cid}]  sub={sub_id}  {msg}")
+        rows.append({"connector_id": cid, "subscription_id": sub_id,
+                     "result": "enabled" if ok else "failed", "note": msg})
+        if not ok:
+            failed += 1
+
+    filename = output_dir / f"connector_restore_{_ts()}.csv"
+    with open(filename, "w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh, fieldnames=["timestamp", "connector_id", "subscription_id", "result", "note"])
+        writer.writeheader()
+        now = datetime.now(timezone.utc).isoformat()
+        for row in rows:
+            writer.writerow({"timestamp": now, **row})
+
+    ok_count = len(to_restore) - failed
+    print(f"\n  Summary: {ok_count} enabled, {failed} failed")
+    log.info("Restore log saved: %s", filename)
+    return 1 if failed else 0
+
+
+# ── CLI wiring ────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Azure → Qualys tenant connector  (all settings in config.json)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config", default="config.json", metavar="FILE",
+        help="Path to JSON config file (default: config.json)",
+    )
+    parser.add_argument(
+        "--output-dir", default=".", metavar="DIR",
+        help="Directory for CSVs and logs (default: current directory)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # create
+    p_create = sub.add_parser("create", help="Discover subscriptions and create connectors")
+    p_create.add_argument("--dry-run", action="store_true",
+                          help="Enumerate Azure subscriptions only; skip all Qualys API calls")
+    p_create.add_argument("--parallel", type=int, default=1, metavar="N",
+                          help="Number of concurrent connector creation threads (default: 1)")
+
+    # list
+    p_list = sub.add_parser("list", help="List all Azure connectors in Qualys")
+    p_list.add_argument("--subscription", metavar="ID",
+                        help="Filter by subscription ID (substring match)")
+
+    # status
+    p_status = sub.add_parser("status", help="Show live state for one or more connector IDs")
+    p_status.add_argument("--ids", metavar="ID", nargs="+", required=True,
+                          help="One or more Qualys connector IDs")
+
+    # list-mgs
+    sub.add_parser("list-mgs", help="Print MG hierarchy — use to pick azure.rootMg in config")
+
+    # delete
+    p_delete = sub.add_parser("delete", help="Delete one or more connectors by Qualys ID")
+    p_delete.add_argument("--ids", metavar="ID", nargs="+", required=True,
+                          help="One or more Qualys connector IDs to delete")
+
+    # restore-orphans
+    sub.add_parser("restore-orphans",
+                   help="Re-enable previously disabled connectors whose subscriptions are now active")
+
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = _setup_logging(output_dir)
+    log.info("Log file: %s", log_path)
+
+    dispatch = {
+        "create":          cmd_create,
+        "list":            cmd_list,
+        "status":          cmd_status,
+        "list-mgs":        cmd_list_mgs,
+        "delete":          cmd_delete,
+        "restore-orphans": cmd_restore_orphans,
+    }
+    sys.exit(dispatch[args.command](args))
+
+
+if __name__ == "__main__":
+    main()

--- a/Connectors/Azure/AzureTenantConnector/qualys_client.py
+++ b/Connectors/Azure/AzureTenantConnector/qualys_client.py
@@ -1,0 +1,684 @@
+"""
+Qualys Connectors API client — creates Azure connectors via the AM module.
+
+Endpoint: POST /qps/rest/3.0/create/am/azureassetdataconnector
+Ref: https://docs.qualys.com/en/conn/api/#t=azure_3%2Fcreate_azure_connector_3.0.htm
+Auth: HTTP Basic (username:password)
+Content-Type: text/xml
+"""
+
+import logging
+import threading
+import time
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+log = logging.getLogger(__name__)
+
+# All Qualys platforms — ref: https://www.qualys.com/platform-identification/
+QUALYS_PLATFORMS: dict[str, str] = {
+    "US1":  "https://qualysapi.qualys.com",
+    "US2":  "https://qualysapi.qg2.apps.qualys.com",
+    "US3":  "https://qualysapi.qg3.apps.qualys.com",
+    "US4":  "https://qualysapi.qg4.apps.qualys.com",
+    "GOV1": "https://qualysapi.gov1.qualys.us",
+    "EU1":  "https://qualysapi.qualys.eu",
+    "EU2":  "https://qualysapi.qg2.apps.qualys.eu",
+    "EU3":  "https://qualysapi.qg3.apps.qualys.it",
+    "IN1":  "https://qualysapi.qg1.apps.qualys.in",
+    "CA1":  "https://qualysapi.qg1.apps.qualys.ca",
+    "AE1":  "https://qualysapi.qg1.apps.qualys.ae",
+    "UK1":  "https://qualysapi.qg1.apps.qualys.co.uk",
+    "AU1":  "https://qualysapi.qg1.apps.qualys.com.au",
+    "KSA1": "https://qualysapi.qg1.apps.qualysksa.com",
+}
+
+QUALYS_US2_BASE = QUALYS_PLATFORMS["US2"]  # kept for backwards compat
+
+def resolve_platform_url(platform_or_url: str) -> str:
+    """
+    Accept either a platform key (e.g. 'CA1') or a full base URL.
+    Returns the API base URL, raising ValueError for unknown keys.
+    """
+    key = platform_or_url.strip().upper()
+    if key in QUALYS_PLATFORMS:
+        return QUALYS_PLATFORMS[key]
+    if platform_or_url.startswith("http"):
+        return platform_or_url.rstrip("/")
+    valid = ", ".join(QUALYS_PLATFORMS)
+    raise ValueError(
+        f"Unknown Qualys platform '{platform_or_url}'. "
+        f"Valid keys: {valid}  — or pass a full URL."
+    )
+
+_CREATE_PATH      = "/qps/rest/3.0/create/am/azureassetdataconnector"
+_SEARCH_PATH      = "/qps/rest/3.0/search/am/azureassetdataconnector"
+_UPDATE_PATH      = "/qps/rest/3.0/update/am/azureassetdataconnector"
+_TAG_SEARCH_PATH  = "/qps/rest/2.0/search/am/tag"
+_TAG_CREATE_PATH  = "/qps/rest/2.0/create/am/tag"
+_DEFAULT_RUN_FREQUENCY = 1440  # minutes (24 hours)
+
+# App-type → connectorAppInfos modules; activation is controlled separately
+APP_TYPE_CONFIG: dict[str, list[str]] = {
+    "AI":  ["AI"],
+    "CSA": ["AI", "CI", "CSA"],
+}
+
+VALID_ACTIVATION_MODULES = ["VM", "CERTVIEW", "SCA", "PC"]
+
+# Qualys connector name max length
+_MAX_NAME_LEN = 255
+
+
+def resolve_connector_name(display_name: Optional[str], subscription_id: str) -> str:
+    """Use the subscription alias if present, else azure-sub-<id>. Caps at 255 chars."""
+    alias = (display_name or "").strip()
+    name = alias if alias else f"azure-sub-{subscription_id}"
+    return name[:_MAX_NAME_LEN]
+
+
+@dataclass
+class ConnectorResult:
+    subscription_id: str
+    subscription_name: str   # display name / alias from Azure
+    connector_name: str      # actual name sent to Qualys
+    management_group: str
+    success: bool
+    connector_id: Optional[str] = None
+    status: str = ""         # "created" | "skipped" | "failed" | "dry_run"
+    note: Optional[str] = None
+
+
+def _xe(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+             .replace("<", "&lt;")
+             .replace(">", "&gt;")
+             .replace('"', "&quot;")
+             .replace("'", "&apos;")
+    )
+
+
+def _build_create_xml(
+    name: str,
+    description: str,
+    subscription_id: str,
+    directory_id: str,
+    application_id: str,
+    authentication_key: str,
+    is_gov_cloud: bool,
+    app_modules: list[str],
+    activation_modules: list[str],
+    run_frequency: int,
+    connector_tag_ids: list[int],
+    asset_tag_ids: list[int],
+) -> str:
+    act_items = "\n".join(
+        f"                    <ActivationModule>{m}</ActivationModule>"
+        for m in activation_modules
+    )
+
+    tags_xml = ""
+    if connector_tag_ids:
+        tag_items = "\n".join(
+            f"                    <TagSimple><id>{tid}</id></TagSimple>"
+            for tid in connector_tag_ids
+        )
+        tags_xml = f"""
+            <defaultTags>
+                <set>
+{tag_items}
+                </set>
+            </defaultTags>"""
+
+    def _app_list(app_name: str) -> str:
+        if asset_tag_ids:
+            entries = "\n".join(
+                f"""                            <ConnectorAppInfo>
+                                <name>{app_name}</name>
+                                <identifier>{_xe(subscription_id)}</identifier>
+                                <tagId>{tid}</tagId>
+                            </ConnectorAppInfo>"""
+                for tid in asset_tag_ids
+            )
+        else:
+            entries = f"""                            <ConnectorAppInfo>
+                                <name>{app_name}</name>
+                                <identifier>{_xe(subscription_id)}</identifier>
+                            </ConnectorAppInfo>"""
+        return f"""                    <ConnectorAppInfoQList>
+                        <set>
+{entries}
+                        </set>
+                    </ConnectorAppInfoQList>"""
+
+    app_lists = "\n".join(_app_list(m) for m in app_modules)
+
+    return f"""<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <data>
+        <AzureAssetDataConnector>
+            <name>{_xe(name)}</name>
+            <description>{_xe(description)}</description>{tags_xml}
+            <activation>
+                <set>
+{act_items}
+                </set>
+            </activation>
+            <disabled>false</disabled>
+            <runFrequency>{run_frequency}</runFrequency>
+            <isRemediationEnabled>false</isRemediationEnabled>
+            <isGovCloudConfigured>{"true" if is_gov_cloud else "false"}</isGovCloudConfigured>
+            <authRecord>
+                <applicationId>{_xe(application_id)}</applicationId>
+                <directoryId>{_xe(directory_id)}</directoryId>
+                <subscriptionId>{_xe(subscription_id)}</subscriptionId>
+                <authenticationKey>{_xe(authentication_key)}</authenticationKey>
+            </authRecord>
+            <connectorAppInfos>
+                <set>
+{app_lists}
+                </set>
+            </connectorAppInfos>
+        </AzureAssetDataConnector>
+    </data>
+</ServiceRequest>"""
+
+
+def _parse_response(xml_text: str) -> tuple[bool, Optional[str], Optional[str]]:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        return False, None, f"XML parse error: {exc}"
+
+    code = root.findtext("responseCode", "")
+    if code == "SUCCESS":
+        return True, root.findtext(".//id"), None
+
+    err = (
+        root.findtext("responseErrorDetails/errorMessage")
+        or root.findtext("responseMessage")
+        or "Unknown error"
+    )
+    return False, None, f"{code}: {err}"
+
+
+class QualysClient:
+    def __init__(self, username: str, password: str, base_url: str = QUALYS_US2_BASE):
+        self._auth = HTTPBasicAuth(username, password)
+        self._base = base_url.rstrip("/")
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Content-Type": "text/xml",
+            "X-Requested-With": "qualys-azure-gov-connector",
+        })
+
+    def _post(self, path: str, body: str, retries: int = 3) -> requests.Response:
+        url = f"{self._base}{path}"
+        for attempt in range(1, retries + 1):
+            resp = self._session.post(url, data=body.encode("utf-8"), auth=self._auth, timeout=60)
+            if resp.status_code == 429 and attempt < retries:
+                wait = int(resp.headers.get("Retry-After", 30))
+                log.warning("Rate-limited, waiting %ds (attempt %d/%d)", wait, attempt, retries)
+                time.sleep(wait)
+                continue
+            return resp
+        return resp
+
+    def _paginated_search(
+        self,
+        path: str,
+        item_tag: str,
+        filters_xml: str = "",
+        page_size: int = 200,
+    ) -> list[ET.Element]:
+        """
+        Fetch all pages from a Qualys search endpoint.
+        Qualys paginates via hasMoreRecords / lastId in the response.
+        """
+        all_items: list[ET.Element] = []
+        start_from_id: Optional[str] = None
+        page = 1
+
+        while True:
+            start_xml = (
+                f"        <startFromId>{start_from_id}</startFromId>\n"
+                if start_from_id else ""
+            )
+            body = f"""<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <preferences>
+        <limitResults>{page_size}</limitResults>
+{start_xml}    </preferences>
+{filters_xml}
+</ServiceRequest>"""
+            resp = self._post(path, body)
+            if resp.status_code != 200:
+                log.warning("_paginated_search HTTP %d on page %d", resp.status_code, page)
+                break
+            try:
+                root = ET.fromstring(resp.text)
+            except ET.ParseError as exc:
+                log.warning("_paginated_search XML parse error on page %d: %s", page, exc)
+                break
+            if root.findtext("responseCode") != "SUCCESS":
+                log.warning("_paginated_search non-success on page %d: %s",
+                            page, root.findtext("responseCode"))
+                break
+
+            items = root.findall(f".//{item_tag}")
+            all_items.extend(items)
+            log.debug("  page %d: %d item(s) fetched (total so far: %d)", page, len(items), len(all_items))
+
+            has_more = root.findtext("hasMoreRecords", "false").lower() == "true"
+            if not has_more:
+                break
+            start_from_id = root.findtext("lastId")
+            if not start_from_id:
+                log.warning("_paginated_search: hasMoreRecords=true but no lastId on page %d", page)
+                break
+            page += 1
+
+        return all_items
+
+    def connector_exists(self, subscription_id: str) -> Optional[str]:
+        log.debug("Checking if connector exists for subscription %s", subscription_id)
+        body = f"""<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <filters>
+        <Criteria field="authRecord.subscriptionId" operator="EQUALS">{_xe(subscription_id)}</Criteria>
+    </filters>
+</ServiceRequest>"""
+        try:
+            resp = self._post(_SEARCH_PATH, body)
+            if resp.status_code == 200:
+                root = ET.fromstring(resp.text)
+                if root.findtext("responseCode") == "SUCCESS":
+                    cid = root.findtext(".//AzureAssetDataConnector/id")
+                    log.debug("  connector_exists → %s", cid or "not found")
+                    return cid
+            log.debug("  connector_exists HTTP %d for sub %s", resp.status_code, subscription_id)
+        except Exception as exc:
+            log.debug("connector_exists check failed for %s: %s", subscription_id, exc)
+        return None
+
+    def create_connector(
+        self,
+        connector_name: str,
+        subscription_id: str,
+        subscription_name: str,
+        management_group: str,
+        directory_id: str,
+        application_id: str,
+        authentication_key: str,
+        description: str = "",
+        is_gov_cloud: bool = True,
+        app_type: str = "CSA",
+        activation_modules: Optional[list[str]] = None,
+        run_frequency: int = _DEFAULT_RUN_FREQUENCY,
+        connector_tag_ids: Optional[list[int]] = None,
+        asset_tag_ids: Optional[list[int]] = None,
+        skip_if_exists: bool = True,
+    ) -> ConnectorResult:
+        app_modules = APP_TYPE_CONFIG.get(app_type.upper(), APP_TYPE_CONFIG["CSA"])
+        activation_modules = activation_modules or []
+        log.debug(
+            "Connector params — app_type=%s app_modules=%s activation=%s gov=%s freq=%d",
+            app_type, app_modules, activation_modules, is_gov_cloud, run_frequency,
+        )
+
+        base_result = dict(
+            subscription_id=subscription_id,
+            subscription_name=subscription_name,
+            connector_name=connector_name,
+            management_group=management_group,
+        )
+
+        if skip_if_exists:
+            existing_id = self.connector_exists(subscription_id)
+            if existing_id:
+                log.info("Already exists for sub %s (id=%s), skipping", subscription_id, existing_id)
+                return ConnectorResult(
+                    **base_result, success=True,
+                    connector_id=existing_id, status="skipped", note="already_exists",
+                )
+
+        body = _build_create_xml(
+            name=connector_name,
+            description=description,
+            subscription_id=subscription_id,
+            directory_id=directory_id,
+            application_id=application_id,
+            authentication_key=authentication_key,
+            is_gov_cloud=is_gov_cloud,
+            app_modules=app_modules,
+            activation_modules=activation_modules,
+            run_frequency=run_frequency,
+            connector_tag_ids=connector_tag_ids or [],
+            asset_tag_ids=asset_tag_ids or [],
+        )
+
+        log.info("Creating connector '%s' (%s)", connector_name, subscription_id)
+        try:
+            resp = self._post(_CREATE_PATH, body)
+        except requests.RequestException as exc:
+            return ConnectorResult(**base_result, success=False, status="failed", note=str(exc))
+
+        log.debug("Response %d: %s", resp.status_code, resp.text[:400])
+        success, cid, error = _parse_response(resp.text)
+
+        if success:
+            log.info("  ✓ id=%s", cid)
+        else:
+            log.warning("  ✗ %s: %s", subscription_id, error)
+
+        return ConnectorResult(
+            **base_result,
+            success=success,
+            connector_id=cid,
+            status="created" if success else "failed",
+            note=error if not success else None,
+        )
+
+    def resolve_tag_names(self, tag_names: list[str]) -> list[int]:
+        log.info("Resolving %d tag name(s): %s", len(tag_names), tag_names)
+        ids = []
+        for name in tag_names:
+            tag_id = self._find_tag(name)
+            if tag_id:
+                log.info("  Tag '%s' found: id=%s", name, tag_id)
+            else:
+                log.info("  Tag '%s' not found — creating …", name)
+                tag_id = self._create_tag(name)
+                if tag_id:
+                    log.info("  Tag '%s' created: id=%s", name, tag_id)
+                else:
+                    log.warning("  Tag '%s' could not be resolved or created", name)
+            if tag_id:
+                ids.append(tag_id)
+        log.info("Resolved tag IDs: %s", ids)
+        return ids
+
+    def _find_tag(self, name: str) -> Optional[int]:
+        log.debug("Searching for tag '%s'", name)
+        body = f"""<ServiceRequest>
+    <filters>
+        <Criteria field="name" operator="EQUALS">{_xe(name)}</Criteria>
+    </filters>
+</ServiceRequest>"""
+        try:
+            resp = self._session.post(
+                f"{self._base}{_TAG_SEARCH_PATH}",
+                data=body.encode(), auth=self._auth, timeout=20,
+            )
+            log.debug("  tag search HTTP %d", resp.status_code)
+            root = ET.fromstring(resp.text)
+            if root.findtext("responseCode") == "SUCCESS":
+                tid = root.findtext(".//Tag/id")
+                return int(tid) if tid else None
+            log.debug("  tag search response: %s", root.findtext("responseCode"))
+        except Exception as exc:
+            log.warning("Tag search failed for '%s': %s", name, exc)
+        return None
+
+    def _create_tag(self, name: str) -> Optional[int]:
+        body = f"""<ServiceRequest>
+    <data>
+        <Tag>
+            <name>{_xe(name)}</name>
+        </Tag>
+    </data>
+</ServiceRequest>"""
+        try:
+            resp = self._session.post(
+                f"{self._base}{_TAG_CREATE_PATH}",
+                data=body.encode(), auth=self._auth, timeout=20,
+            )
+            root = ET.fromstring(resp.text)
+            if root.findtext("responseCode") == "SUCCESS":
+                tid = root.findtext(".//Tag/id")
+                return int(tid) if tid else None
+            err = root.findtext("responseErrorDetails/errorMessage", "")
+            log.warning("Tag create failed for '%s': %s", name, err)
+        except Exception as exc:
+            log.warning("Tag create error for '%s': %s", name, exc)
+        return None
+
+    def list_all_connectors(self) -> list[dict]:
+        """
+        Return ALL Azure connectors in Qualys with pagination.
+        Fields: id, name, subscriptionId, disabled, connectorState.
+        """
+        log.info("Fetching all connectors from Qualys (paginated) …")
+        try:
+            nodes = self._paginated_search(_SEARCH_PATH, "AzureAssetDataConnector")
+            connectors = [
+                {
+                    "id":             node.findtext("id", ""),
+                    "name":           node.findtext("name", ""),
+                    "subscriptionId": (node.findtext("authRecord/subscriptionId") or ""),
+                    "disabled":       node.findtext("disabled", "false").lower() == "true",
+                    "connectorState": node.findtext("connectorState", ""),
+                }
+                for node in nodes
+            ]
+            log.info("  Total connectors in Qualys: %d", len(connectors))
+            return connectors
+        except Exception as exc:
+            log.warning("list_all_connectors failed: %s", exc)
+            return []
+
+    def get_connector_state(self, connector_id: str) -> dict:
+        """
+        Fetch live state of a single connector by ID.
+        Returns a dict with state fields, or an empty dict on failure.
+        """
+        log.debug("Fetching state for connector id=%s", connector_id)
+        body = f"""<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <filters>
+        <Criteria field="id" operator="EQUALS">{_xe(connector_id)}</Criteria>
+    </filters>
+</ServiceRequest>"""
+        try:
+            resp = self._post(_SEARCH_PATH, body)
+            if resp.status_code != 200:
+                log.warning("get_connector_state HTTP %d for id=%s", resp.status_code, connector_id)
+                return {}
+            root = ET.fromstring(resp.text)
+            if root.findtext("responseCode") != "SUCCESS":
+                log.warning("get_connector_state non-success for id=%s: %s",
+                            connector_id, root.findtext("responseCode"))
+                return {}
+            node = root.find(".//AzureAssetDataConnector")
+            if node is None:
+                log.warning("get_connector_state: no connector found for id=%s", connector_id)
+                return {}
+            return {
+                "connector_state":       node.findtext("connectorState", ""),
+                "last_synced_on":        node.findtext("lastSyncedOn", ""),
+                "total_assets_created":  node.findtext("totalAssetsCreated", ""),
+                "total_assets_updated":  node.findtext("totalAssetsUpdated", ""),
+                "total_assets_deleted":  node.findtext("totalAssetsDeleted", ""),
+                "connector_error":       node.findtext("errorDetail", "") or node.findtext("error", ""),
+                "disabled":              node.findtext("disabled", "false"),
+                "run_frequency":         node.findtext("runFrequency", ""),
+            }
+        except Exception as exc:
+            log.warning("get_connector_state failed for id=%s: %s", connector_id, exc)
+            return {}
+
+    def disable_connector(self, connector_id: str) -> tuple[bool, str]:
+        """Disable a connector (sets disabled=true). Returns (success, message)."""
+        log.info("Disabling connector id=%s", connector_id)
+        body = """<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <data>
+        <AzureAssetDataConnector>
+            <disabled>true</disabled>
+        </AzureAssetDataConnector>
+    </data>
+</ServiceRequest>"""
+        try:
+            resp = self._post(f"{_UPDATE_PATH}/{connector_id}", body)
+            log.debug("  disable HTTP %d", resp.status_code)
+            root = ET.fromstring(resp.text)
+            if root.findtext("responseCode") == "SUCCESS":
+                log.info("  ✓ Connector %s disabled", connector_id)
+                return True, "disabled"
+            err = root.findtext("responseErrorDetails/errorMessage") or "Unknown error"
+            log.warning("  ✗ Failed to disable %s: %s", connector_id, err)
+            return False, err
+        except Exception as exc:
+            log.warning("  ✗ Exception disabling %s: %s", connector_id, exc)
+            return False, str(exc)
+
+    def enable_connector(self, connector_id: str) -> tuple[bool, str]:
+        """Re-enable a previously disabled connector. Returns (success, message)."""
+        log.info("Enabling connector id=%s", connector_id)
+        body = """<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <data>
+        <AzureAssetDataConnector>
+            <disabled>false</disabled>
+        </AzureAssetDataConnector>
+    </data>
+</ServiceRequest>"""
+        try:
+            resp = self._post(f"{_UPDATE_PATH}/{connector_id}", body)
+            log.debug("  enable HTTP %d", resp.status_code)
+            root = ET.fromstring(resp.text)
+            if root.findtext("responseCode") == "SUCCESS":
+                log.info("  ✓ Connector %s enabled", connector_id)
+                return True, "enabled"
+            err = root.findtext("responseErrorDetails/errorMessage") or "Unknown error"
+            log.warning("  ✗ Failed to enable %s: %s", connector_id, err)
+            return False, err
+        except Exception as exc:
+            log.warning("  ✗ Exception enabling %s: %s", connector_id, exc)
+            return False, str(exc)
+
+    def disable_orphan_connectors(
+        self,
+        active_subscription_ids: set[str],
+        managed_connector_ids: Optional[set[str]] = None,
+    ) -> list[dict]:
+        """
+        Disable script-managed connectors whose subscriptions are no longer active.
+        managed_connector_ids: IDs previously created by this script (from CSV history).
+          When provided, only those connectors are considered — all others are ignored.
+        Returns list of {id, name, subscriptionId, result, note}.
+        """
+        all_connectors = self.list_all_connectors()
+
+        if managed_connector_ids:
+            before = len(all_connectors)
+            all_connectors = [c for c in all_connectors if c["id"] in managed_connector_ids]
+            log.info("  Scoped to %d script-managed connector(s) (of %d total in Qualys)",
+                     len(all_connectors), before)
+
+        orphans = [
+            c for c in all_connectors
+            if c["subscriptionId"] not in active_subscription_ids and not c["disabled"]
+        ]
+
+        if not orphans:
+            log.info("No orphan connectors found.")
+            return []
+
+        log.info("Found %d orphan connector(s) to disable.", len(orphans))
+        results = []
+        for c in orphans:
+            log.info("  Disabling [%s] %s (sub=%s) …", c["id"], c["name"], c["subscriptionId"])
+            ok, msg = self.disable_connector(c["id"])
+            icon = "✓" if ok else "✗"
+            log.info("    %s %s", icon, msg)
+            results.append({**c, "result": "disabled" if ok else "failed", "note": msg})
+        return results
+
+    def create_connectors_bulk(
+        self,
+        subscriptions: list[dict],
+        directory_id: str,
+        application_id: str,
+        authentication_key: str,
+        is_gov_cloud: bool = True,
+        app_type: str = "CSA",
+        activation_modules: Optional[list[str]] = None,
+        run_frequency: int = _DEFAULT_RUN_FREQUENCY,
+        connector_tag_ids: Optional[list[int]] = None,
+        asset_tag_ids: Optional[list[int]] = None,
+        parallel: int = 1,
+        delay_between: float = 2.0,
+        skip_if_exists: bool = True,
+    ) -> list[ConnectorResult]:
+        """
+        Create connectors for all subscriptions.
+        parallel=1 (default) processes them sequentially with delay_between seconds between each.
+        parallel=N uses N threads; submissions are still paced at delay_between seconds apart
+        to avoid bursting Qualys rate limits.
+        """
+        log.info(
+            "Bulk create — %d subscription(s)  app_type=%s  activation=%s  "
+            "freq=%d min  gov=%s  parallel=%d  delay=%.1fs",
+            len(subscriptions), app_type, activation_modules or [],
+            run_frequency, is_gov_cloud, parallel, delay_between,
+        )
+        total = len(subscriptions)
+        # Pre-allocate result slots so we preserve input order regardless of thread completion order
+        results_map: dict[int, ConnectorResult] = {}
+        lock = threading.Lock()
+
+        def _do_one(idx: int, sub: dict) -> tuple[int, ConnectorResult]:
+            sub_id    = sub["subscriptionId"]
+            disp      = sub.get("displayName", "")
+            mg        = sub.get("managementGroupName", "")
+            conn_name = resolve_connector_name(disp, sub_id)
+            desc      = f"Auto-created — subscription {sub_id}"
+            if mg:
+                desc += f" (MG: {mg})"
+            log.info("[%d/%d] %s", idx, total, conn_name)
+            result = self.create_connector(
+                connector_name=conn_name,
+                subscription_id=sub_id,
+                subscription_name=disp or sub_id,
+                management_group=mg,
+                directory_id=directory_id,
+                application_id=application_id,
+                authentication_key=authentication_key,
+                description=desc,
+                is_gov_cloud=is_gov_cloud,
+                app_type=app_type,
+                activation_modules=activation_modules,
+                run_frequency=run_frequency,
+                connector_tag_ids=connector_tag_ids,
+                asset_tag_ids=asset_tag_ids,
+                skip_if_exists=skip_if_exists,
+            )
+            with lock:
+                results_map[idx] = result
+            return idx, result
+
+        if parallel == 1:
+            for idx, sub in enumerate(subscriptions, start=1):
+                _do_one(idx, sub)
+                if idx < total:
+                    time.sleep(delay_between)
+        else:
+            with ThreadPoolExecutor(max_workers=parallel) as executor:
+                futures = []
+                for idx, sub in enumerate(subscriptions, start=1):
+                    futures.append(executor.submit(_do_one, idx, sub))
+                    # Pace submissions to avoid rate limit bursts
+                    if idx < total:
+                        time.sleep(delay_between)
+                # Ensure all futures complete and surface any exceptions
+                for f in futures:
+                    f.result()
+
+        return [results_map[i] for i in range(1, total + 1)]

--- a/Connectors/Azure/AzureTenantConnector/requirements.txt
+++ b/Connectors/Azure/AzureTenantConnector/requirements.txt
@@ -1,0 +1,6 @@
+azure-identity==1.17.1
+azure-mgmt-resource==23.1.1
+azure-mgmt-managementgroups==1.0.0
+azure-mgmt-subscription==3.1.1
+requests==2.31.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary

- Adds `Connectors/Azure/AzureTenantConnector/` — a Python CLI that discovers all active Azure subscriptions and bulk-creates Qualys Azure connectors
- Supports **Azure Government** and **Azure Commercial** clouds
- Supports all **14 Qualys platforms** plus custom URL
- Full lifecycle: `create`, `list`, `status`, `list-mgs`, `delete`, `restore-orphans`

## What's included

| File | Purpose |
|---|---|
| `main.py` | CLI entry point — all commands, config loading, CSV output |
| `azure_client.py` | Azure MG/subscription discovery (Gov + Commercial) |
| `qualys_client.py` | Qualys Connectors API client |
| `config.example.json` | Full schema reference (no secrets) |
| `requirements.txt` | Python dependencies |
| `README.md` | Customer-shareable documentation |
| `.gitignore` | Excludes `config.json`, CSVs, logs, `.venv` |

## Key features

- **Idempotent** — skips subscriptions that already have a connector; safe to re-run or schedule
- **Parallel creates** — `--parallel N` (default 1, sequential); submissions paced 2s apart to avoid rate limits
- **Tag management** — resolves or creates Qualys tags by name and applies to connectors and assets
- **Orphan detection** — scoped strictly to connectors this script created (via CSV history); never touches connectors created outside the script
- **restore-orphans** — re-enables previously disabled connectors when subscriptions come back into scope
- **--output-dir** — organise CSVs and logs per run/environment
- **Security** — warns at startup if `config.json` is not gitignored

## Test plan

- [x] `list-mgs` — Gov and Commercial
- [x] `create --dry-run` — Gov and Commercial, with and without `--output-dir`
- [x] `create` (live) — Gov (5 subs) and Commercial (2 subs)
- [x] `create` idempotency — re-run shows all skipped
- [x] `create --parallel 2` — thread pool path, order preserved
- [x] `list` and `list --subscription` filter
- [x] `status --ids` (multiple IDs)
- [x] `disableOrphans` — narrowed scope, 3 orphans disabled, 6 pre-existing untouched
- [x] `restore-orphans` — all 3 re-enabled from CSV history
- [x] `delete --ids` — all test connectors cleaned up
- [x] Secret scan — no credentials in any committed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)