### PR TITLE
feat: add cloud resource count scripts (AWS, Azure, GCP, OCI)

### DIFF
--- a/qlu-resource-discovery-tools/.gitignore
+++ b/qlu-resource-discovery-tools/.gitignore
@@ -1,0 +1,13 @@
+# Output files — generated at runtime, not for version control
+*-resources.csv
+*-resources-log.csv
+*-errors-log.txt
+
+# Input files with real account/project/subscription IDs
+projects.txt
+subscriptions.txt
+
+# Python
+__pycache__/
+*.pyc
+.venv/

--- a/qlu-resource-discovery-tools/README.md
+++ b/qlu-resource-discovery-tools/README.md
@@ -1,0 +1,622 @@
+# Qualys Cloud Resource Count Scripts
+
+Python scripts that enumerate and count cloud resources across AWS, Azure, GCP, and OCI for Qualys licensing and inventory purposes. Each script produces CSV output summarizing resource counts by type, account/subscription/project, and region.
+
+Script versions: AWS `2.8.1` · Azure `2.8.4` · GCP `2.8.4` · OCI `2.8.0`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Authentication](#authentication)
+- [Required Permissions](#required-permissions)
+- [Running the Scripts](#running-the-scripts)
+- [Output Files](#output-files)
+- [Resource Types Counted](#resource-types-counted)
+- [AI / LLM Resources](#ai--llm-resources)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Each script connects to one cloud provider, iterates over every active account / subscription / project / compartment, and counts resources by type. Results are printed to stdout in real time and written to CSV files when the run completes.
+
+**Three optional counting modes extend the default set:**
+
+| Flag | What it adds |
+|------|-------------|
+| `--data` | Data Buckets, PaaS Databases, Data Warehouses |
+| `--images` | Registry Container Images (ECR / ACR / GAR) |
+| `--ai` | AI/LLM resources (Bedrock, Azure AI Foundry, Vertex AI) |
+
+All three flags are off by default. They may be combined freely.
+
+---
+
+## Prerequisites
+
+- Python 3.8 or later
+- Cloud provider CLI tools installed and authenticated before running the scripts (see [Authentication](#authentication))
+- Network access to the cloud provider control-plane APIs
+
+---
+
+## Setup
+
+```bash
+# Create and activate a virtual environment (recommended)
+python3 -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+
+# Install dependencies for the cloud(s) you intend to scan
+# (see per-cloud install commands below)
+```
+
+### AWS
+
+```bash
+pip3 install --upgrade boto3 botocore eks_token kubernetes urllib3
+```
+
+### Azure
+
+```bash
+pip3 install --upgrade \
+    azure-mgmt-resourcegraph \
+    azure-containerregistry \
+    azure-identity \
+    azure-mgmt-appcontainers \
+    azure-mgmt-azurestackhci \
+    azure-mgmt-cognitiveservices \
+    azure-mgmt-compute \
+    azure-mgmt-containerinstance \
+    azure-mgmt-containerregistry \
+    azure-mgmt-containerservice \
+    azure-mgmt-hybridcompute \
+    azure-mgmt-sql \
+    azure-mgmt-storage \
+    azure-mgmt-subscription \
+    azure-mgmt-web \
+    azure-storage-blob \
+    msrestazure
+```
+
+For `--ai` mode, also install:
+
+```bash
+pip3 install --upgrade azure-ai-agents azure-ai-projects
+```
+
+### GCP
+
+```bash
+pip3 install --upgrade google-api-python-client
+```
+
+### OCI
+
+```bash
+pip3 install --upgrade oci
+```
+
+---
+
+## Authentication
+
+Authenticate in your shell before running any script. The scripts do not accept credentials as arguments; they rely entirely on ambient credentials from the environment.
+
+### AWS
+
+Configure the AWS CLI or set environment variables:
+
+```bash
+# Option 1: interactive configuration
+aws configure
+
+# Option 2: environment variables
+export AWS_ACCESS_KEY_ID=<key>
+export AWS_SECRET_ACCESS_KEY=<secret>
+export AWS_DEFAULT_REGION=us-east-1
+
+# Verify
+aws sts get-caller-identity
+```
+
+For multi-account scans (`--all` or `--accounts`), the credentials must belong to an IAM principal that can call `sts:AssumeRole` into each member account. The default role name assumed is `OrganizationAccountAccessRole`; override with `--role-name`.
+
+### Azure
+
+```bash
+az login
+az account set --subscription <subscription-id>
+
+# Verify
+az account show
+```
+
+The script uses `azure.identity.DefaultAzureCredential`, which also accepts service principal environment variables (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`) and managed identity when running inside Azure.
+
+### GCP
+
+```bash
+gcloud auth application-default login
+
+# Verify the active project
+gcloud config get-value project
+```
+
+The script calls `google.auth.default()`, so any method that populates Application Default Credentials (ADC) works: `gcloud auth application-default login`, a service account key file via `GOOGLE_APPLICATION_CREDENTIALS`, or a metadata server when running on GCP.
+
+### OCI
+
+```bash
+# Interactive setup — creates ~/.oci/config
+oci setup config
+```
+
+The script reads `~/.oci/config` using the `DEFAULT` profile (`oci.config.DEFAULT_LOCATION`, `oci.config.DEFAULT_PROFILE`). When running inside OCI Cloud Shell, it automatically detects and uses the delegation token at `/etc/oci/delegation_token`.
+
+---
+
+## Required Permissions
+
+The scripts make read-only API calls. Granting the broad read-only managed policies listed below is the fastest path to a working scan. The table of specific actions is provided for teams that require least-privilege custom policies.
+
+### AWS
+
+**Recommended managed policies:** `ReadOnlyAccess`
+
+For a tighter custom policy, the script makes the following API calls:
+
+| Service | boto3 client | Methods called |
+|---------|-------------|----------------|
+| STS | `sts` | `get_caller_identity` |
+| Organizations | `organizations` | `describe_organization`, `list_accounts` |
+| EC2 | `ec2` | `describe_regions`, `describe_instances` |
+| Lightsail | `lightsail` | `get_regions`, `get_instances` |
+| ECS | `ecs` | `list_clusters`, `list_container_instances`, `list_tasks`, `describe_tasks` |
+| EKS | `eks` | `list_clusters`, `list_fargate_profiles`, `describe_cluster` |
+| Lambda | `lambda` | `list_functions`, `list_versions_by_function` |
+| SageMaker | `sagemaker` | `list_domains`, `list_endpoints` |
+| ECR | `ecr` | `describe_repositories`, `list_images` |
+| S3 | `s3` | `list_buckets` |
+| DocumentDB | `docdb` | `describe_db_clusters` |
+| RDS | `rds` | `describe_db_clusters`, `describe_db_instances` |
+| Redshift | `redshift` | `describe_clusters` |
+| DynamoDB | `dynamodb` | `list_tables` |
+| Bedrock | `bedrock` | `list_custom_models` |
+| Bedrock Agent | `bedrock-agent` | `list_agents` |
+
+Minimum IAM actions for a custom policy:
+
+```
+sts:GetCallerIdentity
+organizations:DescribeOrganization
+organizations:ListAccounts
+ec2:DescribeRegions
+ec2:DescribeInstances
+lightsail:GetRegions
+lightsail:GetInstances
+ecs:ListClusters
+ecs:ListContainerInstances
+ecs:ListTasks
+ecs:DescribeTasks
+eks:ListClusters
+eks:ListFargateProfiles
+eks:DescribeCluster
+lambda:ListFunctions
+lambda:ListVersionsByFunction
+sagemaker:ListDomains
+sagemaker:ListEndpoints
+ecr:DescribeRepositories
+ecr:ListImages
+s3:ListAllMyBuckets
+rds:DescribeDBClusters
+rds:DescribeDBInstances
+docdb:DescribeDBClusters
+redshift:DescribeClusters
+dynamodb:ListTables
+bedrock:ListCustomModels
+bedrock-agent:ListAgents
+```
+
+For multi-account scans, the scanning principal also needs:
+
+```
+sts:AssumeRole
+```
+
+on the target account roles.
+
+### Azure
+
+**Recommended role:** `Reader` at subscription scope
+
+For `--ai` mode, additionally assign `Cognitive Services Reader` at subscription scope.
+
+The script instantiates the following SDK clients and calls their list methods:
+
+| SDK Client | Used for | Methods called |
+|-----------|----------|----------------|
+| `SubscriptionClient` | Subscription enumeration | `subscriptions.list`, `subscriptions.get` |
+| `ComputeManagementClient` | VMs, Scale Set VMs | `virtual_machines.list_all`, `virtual_machine_scale_sets.list_all`, `virtual_machine_scale_set_vms.list`, `virtual_machines.get` |
+| `ContainerServiceClient` | AKS nodes | `managed_clusters.list` |
+| `ContainerInstanceManagementClient` | Container Instances | `container_groups.list` |
+| `ContainerAppsAPIClient` | Container Apps | `container_apps.list_by_subscription` |
+| `WebSiteManagementClient` | Web Apps / Functions | `web_apps.list`, `web_apps.list_functions`, `app_service_plans.list` |
+| `HybridComputeManagementClient` | Azure Arc machines | `machines.list_by_subscription` |
+| `AzureStackHCIClient` | Stack HCI clusters | `clusters.list_by_subscription` |
+| `StorageManagementClient` | Storage containers | `storage_accounts.list`, `blob_containers.list` |
+| `SqlManagementClient` | Azure SQL databases | `servers.list`, `databases.list_by_server` |
+| `ContainerRegistryManagementClient` | ACR registry list | `registries.list` |
+| `ContainerRegistryClient` | ACR image tags | `list_repository_names`, `get_repository_properties` |
+| `CognitiveServicesManagementClient` | AI model deployments, AI agents | `accounts.list`, `deployments.list` |
+| `AgentsClient` | AI Agents (OpenAI Assistants) | `list_agents` |
+| `AIProjectClient` | AI Agents (AI Foundry) | `agents.list` |
+| `ResourceGraphClient` | Optional graph mode | `resources` |
+
+### GCP
+
+**Recommended roles:** `roles/viewer` on each project, or `roles/resourcemanager.organizationViewer` + `roles/viewer` for `--all` scans.
+
+The script calls these Google API services. Each service must be enabled on the target project:
+
+| GCP Service API | API name used | Used for |
+|----------------|--------------|----------|
+| Service Usage API | `serviceusage` v1 | Check which APIs are enabled per project |
+| Cloud Resource Manager API | `cloudresourcemanager` v1 | List / get projects |
+| Compute Engine API | `compute` v1 | VM instances, regions, disk images |
+| Kubernetes Engine API | `container` v1 | GKE clusters and Autopilot |
+| Cloud Functions API | `cloudfunctions` v2 | Cloud Functions |
+| Cloud Run API | `run` v1 | Cloud Run revisions |
+| Cloud Storage API | `storage` v1 | Storage buckets |
+| Cloud SQL Admin API | `sqladmin` v1 | Cloud SQL instances |
+| Spanner API | `spanner` v1 | Spanner instances and databases |
+| BigQuery API | `bigquery` v2 | BigQuery datasets |
+| Artifact Registry API | `artifactregistry` v1 | Container images in GAR |
+| Vertex AI API | `aiplatform` v1 | Vertex AI Endpoints |
+| Dialogflow API | `dialogflow` v3 | Vertex AI Agents (Dialogflow CX) |
+
+The script automatically skips any API call for a service that is not enabled in the project's service list, so no errors occur for unused services.
+
+### OCI
+
+**Recommended policy:** A group with `inspect` and `read` verbs on all resource families in the tenancy or target compartments.
+
+Minimum OCI IAM policy statements:
+
+```
+Allow group <ReadGroup> to inspect compartments in tenancy
+Allow group <ReadGroup> to inspect instances in tenancy
+Allow group <ReadGroup> to read instances in tenancy
+Allow group <ReadGroup> to inspect functions-family in tenancy
+Allow group <ReadGroup> to inspect buckets in tenancy
+```
+
+The script uses these OCI SDK clients:
+
+| OCI Client | Used for |
+|-----------|----------|
+| `oci.identity.IdentityClient` | List compartments, regions |
+| `oci.resource_search.ResourceSearchClient` | Query instances, functions, buckets |
+| `oci.core.ComputeClient` | Get image OS details |
+
+---
+
+## Running the Scripts
+
+### AWS
+
+```bash
+# Scan the current account (prompts for nothing; uses ambient credentials)
+python3 resource-count-aws-v2.py
+
+# Scan a specific account ID
+python3 resource-count-aws-v2.py --id 123456789012
+
+# Scan all accounts in the AWS Organization
+python3 resource-count-aws-v2.py --all
+
+# Scan a list of accounts from a file (one 12-digit ID per line)
+python3 resource-count-aws-v2.py --accounts
+# Reads: accounts.txt
+
+# Scan only the regions listed in a file (one region name per line)
+python3 resource-count-aws-v2.py --regions
+# Reads: regions.txt
+
+# Use a custom cross-account role name
+python3 resource-count-aws-v2.py --all --role-name MyReadOnlyRole
+
+# GovCloud partition
+python3 resource-count-aws-v2.py --gov
+
+# China partition
+python3 resource-count-aws-v2.py --china
+
+# Enable data, image, and AI counts
+python3 resource-count-aws-v2.py --data --images --ai
+
+# Tune Lambda version counting (default 5, range 0-10)
+python3 resource-count-aws-v2.py --max-lambda-versions 3
+
+# Tune image tag counting per repository (default 5, range 1-1000)
+python3 resource-count-aws-v2.py --images --max-image-tags 10
+
+# Control parallelism
+python3 resource-count-aws-v2.py --max-workers 16
+
+# Debug mode: sequential execution, exits on first error
+python3 resource-count-aws-v2.py --debug
+
+# Verbose: prints every API response object
+python3 resource-count-aws-v2.py --verbose
+```
+
+### Azure
+
+```bash
+# Scan a specific subscription (interactive prompt if --id is omitted)
+python3 resource-count-azure-v2.py --id <subscription-uuid>
+
+# Scan all subscriptions visible to the authenticated principal
+python3 resource-count-azure-v2.py --all
+
+# Scan subscriptions listed in a file (one UUID per line)
+python3 resource-count-azure-v2.py --subscriptions
+# Reads: subscriptions.txt
+
+# Sovereign cloud modes (mutually exclusive)
+python3 resource-count-azure-v2.py --gov
+python3 resource-count-azure-v2.py --china
+python3 resource-count-azure-v2.py --germany
+
+# Enable data, image, and AI counts
+python3 resource-count-azure-v2.py --data --images --ai
+
+# Enable experimental Azure Resource Graph mode
+python3 resource-count-azure-v2.py --graph
+
+# Tune image tag counting per repository (default 5, range 1-1000)
+python3 resource-count-azure-v2.py --images --max-image-tags 10
+
+# Control parallelism
+python3 resource-count-azure-v2.py --max-workers 16
+
+# Debug and verbose modes
+python3 resource-count-azure-v2.py --debug
+python3 resource-count-azure-v2.py --verbose
+```
+
+### GCP
+
+```bash
+# Scan a specific project (interactive prompt if --id is omitted)
+python3 resource-count-gcp-v2.py --id my-gcp-project-id
+
+# Scan all projects accessible to the authenticated principal
+python3 resource-count-gcp-v2.py --all
+
+# Scan projects listed in a file (one project ID per line)
+python3 resource-count-gcp-v2.py --projects
+# Reads: projects.txt
+
+# Exclude projects in specific folders (one folder ID per line)
+python3 resource-count-gcp-v2.py --all --exclude
+# Reads: excluded-folders.txt
+
+# Enable data, image, and AI counts
+python3 resource-count-gcp-v2.py --data --images --ai
+
+# Tune image tag counting per repository (default 5, range 1-1000)
+python3 resource-count-gcp-v2.py --images --max-image-tags 10
+
+# Control parallelism
+python3 resource-count-gcp-v2.py --max-workers 16
+
+# Debug and verbose modes
+python3 resource-count-gcp-v2.py --debug
+python3 resource-count-gcp-v2.py --verbose
+```
+
+### OCI
+
+```bash
+# Scan all compartments in the tenancy (uses ~/.oci/config DEFAULT profile)
+python3 resource-count-oci.py
+
+# Include bucket counts
+python3 resource-count-oci.py --data
+
+# Control parallelism
+python3 resource-count-oci.py --max-workers 16
+
+# Debug and verbose modes
+python3 resource-count-oci.py --debug
+python3 resource-count-oci.py --verbose
+```
+
+> OCI does not support `--all`, `--id`, `--images`, or `--ai` flags. The script always scans every compartment in the tenancy derived from the active `~/.oci/config` profile.
+
+---
+
+## Output Files
+
+Each script writes three files to the current working directory on completion.
+
+### AWS
+
+| File | Contents |
+|------|----------|
+| `aws-resources.csv` | Summary: `Resource Type, Resource Count` — one row per enabled resource category |
+| `aws-resources-log.csv` | Detail: `Resource Type, Resource Count, Account, Region` — one row per region per account |
+| `aws-errors-log.txt` | One line per API error encountered; only written if errors occurred |
+
+### Azure
+
+| File | Contents |
+|------|----------|
+| `azure-resources.csv` | Summary: `Resource Type, Resource Count` |
+| `azure-resources-log.csv` | Detail: `Resource Type, Resource Count, Subscription` |
+| `azure-errors-log.txt` | API errors; only written if errors occurred |
+
+### GCP
+
+| File | Contents |
+|------|----------|
+| `gcp-resources.csv` | Summary: `Resource Type, Resource Count` |
+| `gcp-resources-log.csv` | Detail: `Resource Type, Resource Count, Project, Region` |
+| `gcp-errors-log.txt` | API errors; only written if errors occurred |
+
+### OCI
+
+| File | Contents |
+|------|----------|
+| `oci-resources.csv` | Summary: `Resource Type, Resource Count` |
+| `oci-resources-log.csv` | Detail: `Resource Type, Resource Count, Region` |
+| `oci-errors-log.txt` | API errors; only written if errors occurred |
+
+---
+
+## Resource Types Counted
+
+The table below maps every resource category to the underlying service and the flag required to enable it.
+
+### AWS (`resource-count-aws-v2.py`)
+
+| Resource Category | Underlying Services | Flag |
+|------------------|--------------------|----|
+| Virtual Machines | EC2 Instances, Lightsail Instances | default |
+| Container Hosts | ECS Container Instances, EKS Nodes | default |
+| Serverless Functions | Lambda Functions + up to N versions | default |
+| Serverless Containers | ECS Fargate Tasks (containers), EKS Fargate Pods, SageMaker Domains, SageMaker Endpoints | default |
+| Non-OS Disks | EBS data volumes attached to EC2 and Lightsail | default |
+| Data Buckets | S3 Buckets (capped at 10,000) | `--data` |
+| PaaS Databases | DocumentDB Clusters, RDS Aurora Clusters, RDS Instances (MariaDB/MySQL/Oracle/PostgreSQL/MSSQL), Redshift Clusters | `--data` |
+| Data Warehouses | DynamoDB Tables (capped at 10,000) | `--data` |
+| Registry Container Images | ECR images (up to `--max-image-tags` tags per repository) | `--images` |
+| Bedrock Custom Models | Custom fine-tuned Bedrock models | `--ai` |
+| Bedrock Agents | Bedrock Agent definitions | `--ai` |
+
+### Azure (`resource-count-azure-v2.py`)
+
+| Resource Category | Underlying Services | Flag |
+|------------------|--------------------|----|
+| Virtual Machines | Compute VMs (excluding Databricks), Scale Set VMs (excluding Databricks) | default |
+| Container Hosts | AKS Managed Cluster node counts | default |
+| Serverless Functions | Web Apps (all kinds), child Functions within Function Apps | default |
+| Serverless Containers | Azure Container Instances (groups), Azure Container Apps | default |
+| Asset Metadata | Azure Arc Machines, Azure Stack HCI Clusters | default |
+| Non-OS Disks | Data disks on Compute VMs and Scale Set VMs | default |
+| Data Buckets | Blob Storage Containers (per storage account, excluding Databricks accounts) | `--data` |
+| PaaS Databases | Azure SQL Databases (excluding `master`) | `--data` |
+| Registry Container Images | ACR images (up to `--max-image-tags` tags per repository) | `--images` |
+| AI Model Deployments | Azure OpenAI and AIServices deployments via Cognitive Services | `--ai` |
+| AI Agents | Azure AI Foundry agents and OpenAI Assistants | `--ai` |
+
+### GCP (`resource-count-gcp-v2.py`)
+
+| Resource Category | Underlying Services | Flag |
+|------------------|--------------------|----|
+| Virtual Machines | Compute Engine Instances (excluding Databricks, excluding GKE nodes) | default |
+| Container Hosts | GKE Standard nodes (identified by `goog-gke-node` label) | default |
+| Serverless Functions | Cloud Functions (v2 API, all locations) | default |
+| Serverless Containers | Cloud Run active revisions, GKE Autopilot pod capacity | default |
+| Non-OS Disks | Non-boot persistent disks on Compute Instances | default |
+| Data Buckets | Cloud Storage Buckets (capped at 10,000) | default* |
+| PaaS Databases | Cloud SQL Instances, Spanner Databases | default* |
+| Data Warehouses | BigQuery Datasets | default* |
+| Registry Container Images | Artifact Registry Docker images (up to `--max-image-tags` tags per image) | `--images` |
+| Vertex AI Endpoints | Vertex AI Endpoints (all locations) | `--ai` |
+| Vertex AI Agents | Dialogflow CX Agents (all locations) | `--ai` |
+
+> *GCP enables Data Buckets, PaaS Databases, and Data Warehouses by default (not gated behind `--data`). The `--data` flag has no effect on GCP currently; those resources are always counted.
+
+### OCI (`resource-count-oci.py`)
+
+| Resource Category | Underlying Services | Flag |
+|------------------|--------------------|----|
+| Virtual Machines | Compute Instances (non-terminated, non-terminating, across all compartments) | default |
+| Container Hosts | OKE-tagged Compute Instances (identified by `Oracle-Tags.CreatedBy = oke`) | default |
+| Serverless Functions | OCI Functions (`functionsfunction` resources) | default |
+| Data Buckets | OCI Object Storage Buckets | `--data` |
+
+> OCI does not currently support `--images` or `--ai` modes.
+
+---
+
+## AI / LLM Resources
+
+The `--ai` flag activates counting of AI/LLM resources on AWS, Azure, and GCP. This section details exactly what is counted and which API endpoint or service is queried.
+
+### AWS — `--ai`
+
+| Resource | boto3 client | Method | Notes |
+|----------|-------------|--------|-------|
+| Bedrock Custom Models | `bedrock` | `list_custom_models` | Counts fine-tuned/custom foundation models per region. Silently skips regions where Bedrock is not available (endpoint resolution errors are suppressed). |
+| Bedrock Agents | `bedrock-agent` | `list_agents` | Counts Bedrock Agent definitions per region. Same endpoint-not-available suppression applies. |
+
+Both resources are scanned in every active region. Regions where Bedrock is not yet available produce no errors.
+
+Required permissions beyond the default set:
+
+```
+bedrock:ListCustomModels
+bedrock-agent:ListAgents
+```
+
+### Azure — `--ai`
+
+| Resource | SDK Client | Method | Notes |
+|----------|-----------|--------|-------|
+| AI Model Deployments | `CognitiveServicesManagementClient` | `accounts.list` + `deployments.list` | Filters to accounts with `kind` of `OpenAI` or `AIServices` only. Counts every deployment within those accounts. |
+| AI Agents | `CognitiveServicesManagementClient` + `AgentsClient` + `AIProjectClient` | `accounts.list` → `list_agents` / `agents.list` | For each OpenAI/AIServices account that exposes an `AI Foundry API` endpoint, counts both OpenAI Assistants (via `AgentsClient`) and AI Foundry template agents (via `AIProjectClient`). Errors per project are logged as verbose output and do not abort the run. |
+
+Required additional packages for `--ai`:
+
+```bash
+pip3 install --upgrade azure-ai-agents azure-ai-projects
+```
+
+Required Azure role beyond `Reader`: `Cognitive Services Reader` at subscription scope.
+
+### GCP — `--ai`
+
+| Resource | Google API | Service string | Method | Notes |
+|----------|-----------|---------------|--------|-------|
+| Vertex AI Endpoints | `aiplatform` v1 | `aiplatform.googleapis.com` | `projects.locations.endpoints.list` with `locations/-` (all locations) | Only runs if `aiplatform.googleapis.com` is enabled in the project's service list. |
+| Vertex AI Agents | `dialogflow` v3 | `dialogflow.googleapis.com` | `projects.locations.agents.list` with `locations/-` (all locations) | Counts Dialogflow CX agents. Only runs if `dialogflow.googleapis.com` is enabled. |
+
+Required GCP roles beyond `roles/viewer`: none — `roles/viewer` includes read access to both APIs.
+
+---
+
+## Troubleshooting
+
+**Script exits with "Missing required ... packages"**
+Run the pip install command printed in the error message, then retry.
+
+**`aws sts get-caller-identity` fails**
+Your AWS credentials are not configured. Run `aws configure` or export `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION`.
+
+**Azure script prompts "Enter the Azure Subscription ID to scan"**
+Neither `--id`, `--all`, nor `--subscriptions` was provided. Pass `--id <uuid>` to avoid the prompt.
+
+**GCP script prompts "Enter the GCP Project ID to scan"**
+Neither `--id`, `--all`, nor `--projects` was provided. Pass `--id <project-id>` to avoid the prompt.
+
+**Errors appear in `*-errors-log.txt` but the run completes**
+Parallel mode continues past individual API failures. Review the log file for access-denied or quota errors, then fix permissions or reduce `--max-workers`. Rerun with `--debug` to convert the first error into a hard stop with a full traceback.
+
+**Bedrock / Vertex AI returns zero counts despite having resources**
+Confirm the service is enabled in that region/project and that the IAM principal has the required read permissions. For Bedrock, the script silently skips regions where the endpoint does not resolve; use `--verbose` to see which regions are skipped.
+
+**OCI "Error reading OCI configuration"**
+Run `oci setup config` to create `~/.oci/config`, or confirm the file exists and contains a `[DEFAULT]` profile with valid `tenancy`, `user`, `fingerprint`, and `key_file` entries.
+
+**Counts seem too high for Lambda**
+The script counts each function plus up to `--max-lambda-versions` published versions per function. The default is 5. Set `--max-lambda-versions 0` to count only the `$LATEST` function and suppress version counting.

--- a/qlu-resource-discovery-tools/README.md
+++ b/qlu-resource-discovery-tools/README.md
@@ -278,7 +278,7 @@ The script calls these Google API services. Each service must be enabled on the 
 | Spanner API | `spanner` v1 | Spanner instances and databases |
 | BigQuery API | `bigquery` v2 | BigQuery datasets |
 | Artifact Registry API | `artifactregistry` v1 | Container images in GAR |
-| Vertex AI API | `aiplatform` v1 | Vertex AI Endpoints |
+| Vertex AI API | `aiplatform` v1 | Vertex AI Endpoints, Vertex AI Models |
 | Dialogflow API | `dialogflow` v3 | Vertex AI Agents (Dialogflow CX) |
 
 The script automatically skips any API call for a service that is not enabled in the project's service list, so no errors occur for unused services.
@@ -533,6 +533,7 @@ The table below maps every resource category to the underlying service and the f
 | Registry Container Images | Artifact Registry Docker images (up to `--max-image-tags` tags per image) | `--images` |
 | Vertex AI Endpoints | Vertex AI Endpoints (all locations) | `--ai` |
 | Vertex AI Agents | Dialogflow CX Agents (all locations) | `--ai` |
+| Vertex AI Models | Vertex AI Models (all locations) | `--ai` |
 
 > *GCP enables Data Buckets, PaaS Databases, and Data Warehouses by default (not gated behind `--data`). The `--data` flag has no effect on GCP currently; those resources are always counted.
 
@@ -590,6 +591,7 @@ Required Azure role beyond `Reader`: `Cognitive Services Reader` at subscription
 |----------|-----------|---------------|--------|-------|
 | Vertex AI Endpoints | `aiplatform` v1 | `aiplatform.googleapis.com` | `projects.locations.endpoints.list` with `locations/-` (all locations) | Only runs if `aiplatform.googleapis.com` is enabled in the project's service list. |
 | Vertex AI Agents | `dialogflow` v3 | `dialogflow.googleapis.com` | `projects.locations.agents.list` with `locations/-` (all locations) | Counts Dialogflow CX agents. Only runs if `dialogflow.googleapis.com` is enabled. |
+| Vertex AI Models | `aiplatform` v1 | `aiplatform.googleapis.com` | `projects.locations.models.list` with `locations/-` (all locations) | Only runs if `aiplatform.googleapis.com` is enabled in the project's service list. |
 
 Required GCP roles beyond `roles/viewer`: none — `roles/viewer` includes read access to both APIs.
 
@@ -620,3 +622,8 @@ Run `oci setup config` to create `~/.oci/config`, or confirm the file exists and
 
 **Counts seem too high for Lambda**
 The script counts each function plus up to `--max-lambda-versions` published versions per function. The default is 5. Set `--max-lambda-versions 0` to count only the `$LATEST` function and suppress version counting.
+
+---
+
+## Author
+Yash Jhunjhunwala, Lead SME Cloud Security Solutions

--- a/qlu-resource-discovery-tools/resource-count-aws-v2.py
+++ b/qlu-resource-discovery-tools/resource-count-aws-v2.py
@@ -1,0 +1,1462 @@
+#!/usr/bin/env python3
+
+# pylint: disable=invalid-name, too-many-lines
+
+""" Qualys : Resource Count : AWS """
+
+import argparse
+import concurrent.futures
+import csv
+import inspect
+import os
+import signal
+import sys
+
+# As a single script download, we do not publish a requirements.txt. Autodocument.
+
+try:
+    import boto3
+    import eks_token
+    import kubernetes
+    import urllib3
+    from botocore.config import Config
+except ImportError:
+    print("\nERROR: Missing required AWS SDK packages. Run the following command to install/upgrade:\n")
+    print("pip3 install --upgrade boto3 botocore eks_token kubernetes urllib3")
+    sys.exit(1)
+
+
+version='2.8.1'
+
+
+####
+# Command Line Arguments
+####
+
+
+DEFAULT_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+
+parser = argparse.ArgumentParser(description = 'Count AWS Resources')
+parser.add_argument(
+    '--all',
+    action = 'store_true',
+    dest = 'all',
+    help = 'Count resources in all Accounts in the current AWS Organization (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--id',
+    dest = 'id',
+    help = 'Count resources in the specified AWS Account (default: the ID of the current account)',
+    default = None
+)
+parser.add_argument(
+    '--accounts',
+    action = 'store_true',
+    dest = 'input_accounts',
+    help = 'Count resources in the list of AWS Accounts (one ID per line) in a file named accounts.txt (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--regions',
+    action = 'store_true',
+    dest = 'input_regions',
+    help = 'Count resources in the list of AWS Regions (one per line) in a file named regions.txt (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--role-name',
+    action = 'store',
+    dest = 'role_name',
+    help = 'Specify the AWS IAM role name to use when assuming access to other AWS Accounts (default: OrganizationAccountAccessRole)',
+    default = 'OrganizationAccountAccessRole'
+)
+parser.add_argument(
+    '--data',
+    action = 'store_true',
+    dest = 'data_mode',
+    help = 'Count Qualys Cloud Data Security (Buckets, Databases, etc) resources (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--images',
+    action = 'store_true',
+    dest = 'images_mode',
+    help = 'Count Qualys Cloud Registry Container Images (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--ai',
+    action = 'store_true',
+    dest = 'ai_mode',
+    help = 'Count AI/LLM resources (Bedrock Custom Models, Bedrock Agents) (default: disabled)',
+    default = False
+)
+pgroup = parser.add_mutually_exclusive_group()
+pgroup.add_argument(
+    '--gov',
+    action = 'store_true',
+    dest = 'use_gov',
+    help = 'Use GovCloud regions (default: disabled)',
+    default = False
+)
+pgroup.add_argument(
+    '--china',
+    action = 'store_true',
+    dest = 'use_china',
+    help = 'Use China regions (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--max-lambda-versions',
+    action = 'store',
+    dest = 'max_lambda_versions',
+    help = 'Number of versions to count per Lambda Function (default: 5, range 0 to 10)',
+    type = int,
+    default = 5
+)
+parser.add_argument(
+    '--max-image-tags',
+    action = 'store',
+    dest = 'max_image_tags',
+    help = 'Number of image tags to count per registry image (default: 5, range 1 to 1000)',
+    type = int,
+    default = 5
+)
+parser.add_argument(
+    '--max-workers',
+    dest = 'max_workers',
+    help = f'Maximum parallel processing requests (default: {DEFAULT_MAX_WORKERS}, range 1 to 255)',
+    type = int,
+    default = DEFAULT_MAX_WORKERS
+)
+parser.add_argument(
+    '--debug',
+    action = 'store_true',
+    dest = 'debug_mode',
+    help = 'Disable parallel processing and exit upon first error (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--verbose',
+    action = 'store_true',
+    dest = 'verbose_mode',
+    help = 'Output verbose debugging information (default: disabled)',
+    default = False
+)
+args = parser.parse_args()
+
+if args.max_lambda_versions < 0 or args.max_lambda_versions > 10:
+    print(f"ERROR: --max-lambda-versions {args.max_lambda_versions} out of range: [0 .. 10]")
+    sys.exit(1)
+if args.max_image_tags < 1 or args.max_image_tags > 1000:
+    print(f"ERROR: --max-image-tags {args.max_image_tags} out of range: [1 .. 1000]")
+    sys.exit(1)
+if args.max_workers < 1 or args.max_workers > 255:
+    print(f"ERROR: --max-workers {args.max_workers} out of range: [1 .. 255]")
+    sys.exit(1)
+
+
+####
+# Configuration and Globals
+####
+
+accounts_file   = 'accounts.txt'
+regions_file    = 'regions.txt'
+output_file     = 'aws-resources.csv'
+output_file_log = 'aws-resources-log.csv'
+error_log_file  = 'aws-errors-log.txt'
+padding = 6
+
+# Map command-line arguments to counts to execute and display.
+enabled = {
+    'Virtual Machines':             True,
+    'Container Hosts':              True,
+    'Serverless Functions':         True,
+    'Serverless Containers':        True,
+
+    'Data Buckets':                 args.data_mode,
+    'PaaS Databases':               args.data_mode,
+    'Data Warehouses':              args.data_mode,
+
+    'Non-OS Disks':                 True,
+
+    'Registry Container Images':    args.images_mode,
+
+    'Bedrock Custom Models':        args.ai_mode,
+    'Bedrock Agents':               args.ai_mode,
+
+}
+
+totals = {
+    'Virtual Machines':              0,
+    'Container Hosts':               0,
+    'Serverless Functions':          0,
+    'Serverless Containers':         0,
+
+    'Data Buckets':                  0,
+    'PaaS Databases':                0,
+    'Data Warehouses':               0,
+
+    'Non-OS Disks':                  0,
+    'Registry Container Images':     0,
+
+    'Bedrock Custom Models':         0,
+    'Bedrock Agents':                0,
+
+}
+
+totals_log = []
+errors_log = []
+
+
+try:
+    aws_api_config = Config(
+        retries = {
+            'max_attempts' : 10,
+            'mode'         : 'adaptive'
+        }
+    )
+except Exception as ex0:  # pylint: disable=broad-exception-caught
+    print("\nERROR: ")
+    print(ex0)
+    print("Unable to authenticate. Please verify your configuration")
+    sys.exit(1)
+
+
+####
+# Common Library Code
+####
+
+
+def signal_handler(_signal_received, _frame):
+    """ Control-C """
+    print("\nExiting")
+    sys.exit(0)
+
+
+def progress_print(resource_count, resource_type, account='', region='', details=''):
+    """ Resource output """
+    rc = str(resource_count).rjust(padding)
+    # Split and join to remove multiple spaces when variables are empty.
+    print(' '.join(f"- {rc} {resource_type} in {region} {details}".split()))
+    totals_log.append([resource_type, resource_count, account, region])
+
+
+def verbose_print(details):
+    """ Verbose output """
+    if args.verbose_mode:
+        print(f"\nDEBUG: {details}")
+
+
+def error_print(details, account=''):
+    """ Error output """
+    account  = f"Account: {account} " if account else ""
+    try:
+        function = f"{inspect.stack()[1].function}()"
+    except Exception:  # pylint: disable=broad-exception-caught
+        function = ''
+    try:
+        details = str(details).replace("\n", " ").replace("\r", " ")
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    print(f"\nERROR: {account} {function} {details}\n")
+    errors_log.append(f"ERROR: {account} {function} {details}")
+
+
+####
+# Customized Library Code
+####
+
+
+# Pagination:
+# Some AWS services use NextToken, nextToken, Marker, or Marker/NextMarker:
+# https://github.com/iann0036/aws-pagination-rules/blob/master/README.md
+# See also: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html
+
+
+def select_default_region():
+    """ Select the default region based upon environment (aws, aws-cn, aws-us-gov) """
+    if args.use_gov:
+        return 'us-gov-east-1'
+    if args.use_china:
+        return 'cn-north-1'
+    return 'us-east-1'
+
+
+def tag_in_tags(tag_key, tag_value, tags):
+    """ Check for tag key and value """
+    if not tags:
+        return False
+    for tag in tags:
+        if tag['Key'] == tag_key and tag['Value'] == tag_value:
+            return True
+    return False
+
+
+# Subscriptions (aka AWS Accounts)
+
+
+def get_aws_organization():
+    """ Get Active Accounts in an AWS Organization """
+    root_account_id = None
+    accounts = []
+    RESTORE_AWS_STS_REGIONAL_ENDPOINTS = os.environ.pop('AWS_STS_REGIONAL_ENDPOINTS', None)
+    try:
+        os.environ['AWS_STS_REGIONAL_ENDPOINTS'] = 'regional'
+        client = boto3.client('organizations', region_name=select_default_region(), config=aws_api_config)
+        root_account_id = client.describe_organization()['Organization']['MasterAccountId']
+        response = client.list_accounts()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting AWS Organization.")
+        if RESTORE_AWS_STS_REGIONAL_ENDPOINTS is None:
+            del os.environ['AWS_STS_REGIONAL_ENDPOINTS']
+        else:
+            os.environ['AWS_STS_REGIONAL_ENDPOINTS'] = RESTORE_AWS_STS_REGIONAL_ENDPOINTS
+        return root_account_id, accounts
+    for account in response['Accounts']:
+        verbose_print(f"account: {account}")
+        if account['Status'] != 'ACTIVE':
+            continue
+        accounts.append(account)
+    while 'NextToken' in response:
+        response = client.list_accounts(NextToken=response['NextToken'])
+        for account in response['Accounts']:
+            verbose_print(f"account: {account}")
+            if account['Status'] != 'ACTIVE':
+                continue
+            accounts.append(account)
+    if RESTORE_AWS_STS_REGIONAL_ENDPOINTS is None:
+        del os.environ['AWS_STS_REGIONAL_ENDPOINTS']
+    else:
+        os.environ['AWS_STS_REGIONAL_ENDPOINTS'] = RESTORE_AWS_STS_REGIONAL_ENDPOINTS
+    return root_account_id, accounts
+
+
+def get_aws_account():
+    """ Get AWS Account (UserId, Account, Arn) """
+    try:
+        client = boto3.client('sts')
+        account = client.get_caller_identity()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting current AWS Account.")
+    verbose_print(f"account: {account}")
+    return account
+
+
+def get_aws_accounts_from_file():
+    """Get the list of AWS Accounts """
+    accounts = []
+    if os.path.isfile(accounts_file):
+        try:
+            with open(accounts_file, 'r', encoding='utf-8') as file:
+                for line in file:
+                    account_id = line.strip()
+                    # Verify the AWS Account ID is 12 digits.
+                    if account_id and account_id.isdigit() and len(account_id) == 12:
+                        accounts.append({'Id': account_id, 'Name': account_id})
+                    else:
+                        print(f"Skipping invalid Account ID from {accounts_file}: {account_id}")
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex)
+            print("Error getting AWS Accounts from file.")
+            print("Exiting...")
+            sys.exit(1)
+    else:
+        print("Input file does not exist.")
+        print(f"Create a file named {accounts_file} and add each AWS Account ID to scan, one per line.")
+        print("Exiting...")
+        sys.exit(1)
+    return accounts
+
+
+def aws_get_credentials(target_account_id, current_account_id, root_account_id):
+    """ Get AWS Credentials to access the target account """
+    # pylint: disable=consider-using-in
+    if target_account_id == current_account_id or target_account_id == root_account_id:
+        try:
+            session = boto3.Session()
+            credentials = session.get_credentials()
+            credentials = credentials.get_frozen_credentials()
+            return {
+                'AccessKeyId':     credentials.access_key,
+                'SecretAccessKey': credentials.secret_key,
+                'SessionToken':    credentials.token
+            }
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, target_account_id)
+            return None
+    try:
+        client = boto3.client('sts', config=aws_api_config)
+        aws_partition = "arn:aws:iam::"
+        if args.use_gov:
+            aws_partition = "arn:aws-us-gov:iam::"
+        elif args.use_china:
+            aws_partition = "arn:aws-cn:iam::"
+        assumed_role_object = client.assume_role(
+            # Example: arn:aws:iam::123456789012:role/MyRoleName
+            RoleArn=aws_partition + str(target_account_id) + ':role/' + args.role_name,
+            RoleSessionName='Session1'
+        )
+        credentials = assumed_role_object['Credentials']
+        return {
+            'AccessKeyId':     credentials['AccessKeyId'],
+            'SecretAccessKey': credentials['SecretAccessKey'],
+            'SessionToken':    credentials['SessionToken']
+        }
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, target_account_id)
+        return None
+
+
+def get_aws_regions(credentials):
+    """ Get AWS Regions, using the "default" AWS region for the partition (aws, aws-cn, aws-us-gov) """
+    client = get_aws_client('ec2', select_default_region(), credentials)
+    try: # pylint: disable=broad-exception-caught
+        response = client.describe_regions(AllRegions=False)
+        regions = response['Regions']
+        regions = sorted(regions, key=lambda d: d['RegionName'])
+        verbose_print(f"regions: {regions}")
+        return regions
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting AWS Regions.")
+        return []
+
+
+def get_aws_lightsail_region_names(credentials):
+    """ Get AWS Lightsail Regions, which are a subset of all AWS Regions """
+    client = get_aws_client('lightsail', select_default_region(), credentials)
+    try: # pylint: disable=broad-exception-caught
+        response = client.get_regions()
+        regions = response['regions']
+        regions = sorted(region['name'] for region in regions)
+        verbose_print(f"lightsail regions: {regions}")
+        return regions
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting AWS Lightsail Regions.")
+        return []
+
+
+def get_aws_regions_from_file():
+    """Get the list of AWS Regions """
+    regions = []
+    if os.path.isfile(regions_file):
+        try:
+            with open(regions_file, 'r', encoding='utf-8') as file:
+                for line in file:
+                    region = line.strip()
+                    regions.append({'RegionName': region})
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex)
+            print("Error getting AWS Regions from file.")
+            print("Exiting...")
+            sys.exit(1)
+    else:
+        print("Regions file does not exist.")
+        print(f"Create a file named {regions_file} and add each AWS Region to scan, one per line.")
+        print("Exiting...")
+        sys.exit(1)
+    return regions
+
+
+def get_aws_client(service, region, credentials):
+    """ Return an AWS Client """
+    try:
+        client = boto3.client(
+            service,
+            region_name           = region,
+            config                = aws_api_config,
+            aws_access_key_id     = credentials['AccessKeyId'],
+            aws_secret_access_key = credentials['SecretAccessKey'],
+            aws_session_token     = credentials['SessionToken']
+        )
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        print("Error getting AWS Client.")
+        print("Exiting...")
+        sys.exit(1)
+    return client
+
+
+# Virtual Machines: EC2 Instances
+
+
+def get_aws_ec2_instances(region, credentials, account):
+    """ Get AWS EC2 Instances (and the number of non-os disks) in the specified Account and Region """
+    instances_count = 0
+    non_os_disks_count = 0
+    linux_instances_count = 0
+    client = get_aws_client('ec2', region, credentials)
+    try:
+        response = client.describe_instances(MaxResults=1000)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    for reservation in response['Reservations']:
+        if 'Instances' in reservation:
+            for instance in reservation['Instances']:
+                verbose_print(f"instance: {instance}")
+                if instance['State']['Name'] == 'terminated':
+                    continue
+                if tag_in_tags('Vendor', 'Databricks', instance.get('Tags', {})):
+                    verbose_print(f"Skipping Databricks instance: {instance['Tags']}")
+                    continue
+                instances_count += 1
+                non_os_disks_count += get_aws_ec2_instance_non_os_disks_count(instance)
+                if 'PlatformDetails' in instance and 'win' not in instance['PlatformDetails'].lower():
+                    linux_instances_count += 1
+    while 'NextToken' in response:
+        try:
+            response = client.describe_instances(NextToken=response['NextToken'], MaxResults=1000)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        for reservation in response['Reservations']:
+            if 'Instances' in reservation:
+                for instance in reservation['Instances']:
+                    verbose_print(f"instance: {instance}")
+                    if instance['State']['Name'] == 'terminated':
+                        continue
+                    if tag_in_tags('Vendor', 'Databricks', instance.get('Tags', {})):
+                        verbose_print(f"Skipping Databricks instance: {instance['Tags']}")
+                        continue
+                    instances_count += 1
+                    non_os_disks_count += get_aws_ec2_instance_non_os_disks_count(instance)
+                    if 'PlatformDetails' in instance and 'win' not in instance['PlatformDetails'].lower():
+                        linux_instances_count += 1
+
+    if instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=instances_count, resource_type='Virtual Machines [EC2]', region=region, account=account['Name'], details=f"with {non_os_disks_count} Non-OS Disks")
+        totals['Virtual Machines'] += instances_count
+        totals['Non-OS Disks'] += non_os_disks_count
+
+
+def get_aws_ec2_instance_non_os_disks_count(instance):
+    """ Get the volume count for data volumes of the specified EC2 Instance """
+    non_os_disks_count = 0
+    if 'BlockDeviceMappings' in instance:
+        if len(instance['BlockDeviceMappings']) > 0:
+            root_volume = instance['BlockDeviceMappings'][0]['Ebs']['VolumeId']
+            for volume in instance['BlockDeviceMappings']:
+                if volume['Ebs']['VolumeId'] != root_volume:
+                    non_os_disks_count += 1
+    return non_os_disks_count
+
+
+# Virtual Machines: LightSail Instances
+
+
+def get_aws_lightsail_instances(region, credentials, account):
+    """ Get AWS Lightsail Instances (and the number of non-os disks) in the specified Account """
+    instances_count = 0
+    non_os_disks_count = 0
+    linux_instances_count = 0
+    client = get_aws_client('lightsail', region, credentials)
+    try:
+        response = client.get_instances()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    for instance in response['instances']:
+        verbose_print(f"instance: {instance}")
+        if instance['resourceType'] != 'Instance':
+            continue
+        if instance['state']['name'] == 'terminated':
+            continue
+        instances_count += 1
+        non_os_disks_count += get_aws_lightsail_non_os_disks_count(instance)
+        if 'PlatformDetails' in instance and 'win' not in instance['PlatformDetails'].lower():
+            linux_instances_count += 1
+    while 'nextPageToken' in response:
+        try:
+            response = client.get_instances(pageToken=response['nextPageToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        for instance in response['instances']:
+            verbose_print(f"instance: {instance}")
+            if instance['resourceType'] != 'Instance':
+                continue
+            if instance['state']['name'] == 'terminated':
+                continue
+            instances_count += 1
+            non_os_disks_count += get_aws_lightsail_non_os_disks_count(instance)
+            if 'PlatformDetails' in instance and 'win' not in instance['PlatformDetails'].lower():
+                linux_instances_count += 1
+
+    if instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=instances_count, resource_type='Virtual Machines [Lightsail]', region=region, account=account['Name'], details=f"with {non_os_disks_count} Non-OS Disks")
+        totals['Virtual Machines'] += instances_count
+        totals['Non-OS Disks'] += non_os_disks_count
+
+
+def get_aws_lightsail_non_os_disks_count(instance):
+    """ Get the volume count for data disks of the specified Lightsail Instance """
+    non_os_disks_count = 0
+    if 'hardware' in instance and 'disks' in instance['hardware']:
+        for disk in instance['hardware']['disks']:
+            if disk['isSystemDisk'] is True:
+                continue
+            if disk['isAttached'] is not True:
+                continue
+            non_os_disks_count += 1
+    return non_os_disks_count
+
+
+# Container Hosts: ECS
+
+
+def get_aws_ecs_container_instances(region, credentials, account):
+    """ Get AWS ECS Container Hosts in the specified Account """
+    ecs_clusters = []
+    ecs_instances_count = 0
+    client = get_aws_client('ecs', region, credentials)
+    try:
+        response = client.list_clusters()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    ecs_clusters.extend(response['clusterArns'])
+    while 'nextToken' in response:
+        try:
+            response = client.list_clusters(nextToken=response['nextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        ecs_clusters.extend(response['clusterArns'])
+    for cluster in ecs_clusters:
+        try:
+            response = client.list_container_instances(cluster=cluster)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        ecs_instances_count += len(response['containerInstanceArns'])
+        while 'nextToken' in response:
+            try:
+                response = client.list_container_instances(cluster=cluster, nextToken=response['nextToken'])
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                response = {}
+                error_print(ex, account['Id'])
+                continue
+            ecs_instances_count += len(response['containerInstanceArns'])
+
+    if ecs_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=ecs_instances_count, resource_type='Container Hosts [ECS]', region=region, account=account['Name'])
+        totals['Container Hosts'] += ecs_instances_count
+
+
+# Container Hosts: EKS
+
+# pylint: disable=too-many-statements
+def get_aws_eks_instances(region, credentials, account):
+    """ Get AWS EKS Container Hosts in the specified Account """
+    eks_clusters = []
+    eks_instances_count = 0
+    eks_containers_count = 0
+    eks_client = get_aws_client('eks', region, credentials)
+    try:
+        response = eks_client.list_clusters()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    eks_clusters.extend(response['clusters'])
+    while 'nextToken' in response:
+        try:
+            response = eks_client.list_clusters(nextToken=response['nextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        eks_clusters.extend(response['clusters'])
+    ec2_client = get_aws_client('ec2', region, credentials)
+    # Search for instances with the 'kubernetes.io/cluster/<cluster-name>' tag per cluster.
+    for cluster_name in eks_clusters:
+        try:
+            response = ec2_client.describe_instances(Filters=[{'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/' + cluster_name]}])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        for reservation in response['Reservations']:
+            if 'Instances' in reservation:
+                for instance in reservation['Instances']:
+                    verbose_print(f"instance: {instance}")
+                    if instance['State']['Name'] == 'terminated':
+                        continue
+                    eks_instances_count += 1
+        while 'NextToken' in response:
+            try:
+                response = ec2_client.describe_instances(Filters=[{'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/' + cluster_name]}], NextToken=response['NextToken'])
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                response = {}
+                error_print(ex, account['Id'])
+                continue
+            for reservation in response['Reservations']:
+                if 'Instances' in reservation:
+                    for instance in reservation['Instances']:
+                        verbose_print(f"instance: {instance}")
+                        if instance['State']['Name'] == 'terminated':
+                            continue
+                        eks_instances_count += 1
+    # Search for Fargate profiles per cluster.
+    for cluster_name in eks_clusters:
+        try:
+            fargate_profiles_response = eks_client.list_fargate_profiles(clusterName=cluster_name)
+            fargate_profiles = fargate_profiles_response.get('fargateProfileNames', [])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            fargate_profiles = []
+            error_print(ex, account['Id'])
+            continue
+        if fargate_profiles:
+            eks_containers_count += get_aws_cluster_fargate_pod_count(eks_client, cluster_name, account)
+        while 'NextToken' in response:
+            try:
+                fargate_profiles_response = eks_client.list_fargate_profiles(clusterName=cluster_name, NextToken=response['NextToken'])
+                fargate_profiles = fargate_profiles_response.get('fargateProfileNames', [])
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                fargate_profiles = []
+                error_print(ex, account['Id'])
+                continue
+            if fargate_profiles:
+                eks_containers_count += get_aws_cluster_fargate_pod_count(eks_client, cluster_name, account)
+
+    if eks_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=eks_instances_count, resource_type='Container Hosts [EKS]', region=region, account=account['Name'])
+        totals['Container Hosts'] += eks_instances_count
+    if eks_containers_count > 0 or args.verbose_mode:
+        progress_print(resource_count=eks_containers_count, resource_type='Serverless Containers [EKS Fargate]', region=region, account=account['Name'])
+        totals['Serverless Containers'] += eks_containers_count
+
+
+def get_aws_cluster_fargate_pod_count(eks_client, cluster_name, account):
+    """ Use a Kubernetes client to count pods running on Fargate """
+    pod_count = 0
+    # Unfortunately, the kubernetes-python client does not allow for inlining the TLS CA Certificate.
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    try:
+        cluster_token = eks_token.get_token(cluster_name)
+        cluster_token = cluster_token['status']['token']
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        error_print('Unable to get fargate cluster token. Using default count of 1', account['Id'])
+        return 1
+    try:
+        cluster_data = eks_client.describe_cluster(name=cluster_name)
+        cluster_data = cluster_data['cluster']
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        error_print('Unable to describe fargate cluster. Using default count of 1', account['Id'])
+        return 1
+    kconfig = kubernetes.config.kube_config.Configuration(
+        api_key = {'authorization': 'Bearer ' + cluster_token},
+        host    = cluster_data['endpoint'],
+    )
+    kconfig.verify_ssl = False
+    kubernetes_api_client = kubernetes.client.ApiClient(configuration=kconfig)
+    kubernetes_client = kubernetes.client.CoreV1Api(api_client=kubernetes_api_client)
+    try:
+        pods = kubernetes_client.list_pod_for_all_namespaces(timeout_seconds=4, watch=False)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        error_print('Unable to list fargate pod. Using default count of 1', account['Id'])
+        return 1
+    for pod in pods.items:
+        node_name = pod.spec.node_name
+        if node_name and node_name.startswith('fargate'):
+            pod_count +=1
+    return pod_count
+
+
+# Serverless Functions: Lambda Functions
+
+
+def get_aws_lambda_functions(region, credentials, account):
+    """ Get AWS Lambda Functions in the specified Account """
+    serverless_functions_count = 0
+    client = get_aws_client('lambda', region, credentials)
+    try:
+        response = client.list_functions(MaxItems=1000)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    functions = response['Functions']
+    serverless_functions_count += len(functions)
+    while 'NextMarker' in response:
+        try:
+            response = client.list_functions(Marker=response['NextMarker'], MaxItems=1000)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        functions.extend(response['Functions'])
+        serverless_functions_count += len(response['Functions'])
+    serverless_functions_versions_count = 0
+    # Qualys inspects a default of 5 (new Tenants) up to 10 (via Settings) versions.
+    if args.max_lambda_versions > 0:
+        for function in functions:
+            versions = get_aws_lambda_function_versions(account, region, credentials, function['FunctionArn'])
+            versions_count = min(args.max_lambda_versions, len(versions))
+            serverless_functions_versions_count += versions_count
+
+    if serverless_functions_count > 0 or args.verbose_mode:
+        serverless_functions_count += serverless_functions_versions_count
+        progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [Lambda]', region=region, account=account['Name'])
+        totals['Serverless Functions'] += serverless_functions_count
+
+
+# Serverless Functions: Lambda Function Versions
+
+
+def get_aws_lambda_function_versions(account, region, credentials, function_arn):
+    """ Get AWS Lambda Function Versions for the specified Function """
+    versions = []
+    client = get_aws_client('lambda', region, credentials)
+    try:
+        response = client.list_versions_by_function(FunctionName=function_arn, MaxItems=args.max_lambda_versions)
+        versions.extend(response['Versions'])
+        versions = [v for v in versions if v['Version'] != '$LATEST']
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+    return versions
+
+
+# Serverless Containers: ECS Fargate
+
+
+def get_aws_ecs_resources(region, credentials, account):
+    """ Get AWS Fargate Containers in the specified Account """
+    ecs_clusters = []
+    ecs_containers_count = 0
+    ecs_tasks_count = 0
+    client = get_aws_client('ecs', region, credentials)
+    try:
+        response = client.list_clusters()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    ecs_clusters.extend(response['clusterArns'])
+    while 'nextToken' in response:
+        try:
+            response = client.list_clusters(nextToken=response['nextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        ecs_clusters.extend(response['clusterArns'])
+    for cluster in ecs_clusters:
+        try:
+            response = client.list_tasks(cluster=cluster, launchType='FARGATE')
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        if response['taskArns']:
+            describe_tasks_response = client.describe_tasks(cluster=cluster, tasks=response['taskArns'])
+            for task in describe_tasks_response['tasks']:
+                ecs_containers_count += len(task['containers'])
+            ecs_tasks_count += len(describe_tasks_response['tasks'])
+        while 'nextToken' in response:
+            try:
+                response = client.list_tasks(cluster=cluster, launchType='FARGATE', nextToken=response['nextToken'])
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                response = {}
+                error_print(ex, account['Id'])
+                continue
+            if response['taskArns']:
+                describe_tasks_response = client.describe_tasks(cluster=cluster, tasks=response['taskArns'])
+                for task in describe_tasks_response['tasks']:
+                    ecs_containers_count += len(task['containers'])
+                ecs_tasks_count += len(describe_tasks_response['tasks'])
+
+    if ecs_containers_count > 0 or args.verbose_mode:
+        progress_print(resource_count=ecs_containers_count, resource_type='Serverless Containers [ECS Fargate]', region=region, account=account['Name'])
+        totals['Serverless Containers'] += ecs_containers_count
+
+
+# Serverless Containers: SageMaker Domains
+
+
+def get_aws_sagemaker_domains(region, credentials, account):
+    """ Get AWS SageMaker Domains in the specified Account """
+    sagemaker_domains_count = 0
+    client = get_aws_client('sagemaker', region, credentials)
+    try:
+        response = client.list_domains()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    sagemaker_domains_count += len(response['Domains'])
+    while 'NextToken' in response:
+        try:
+            response = client.list_domains(NextToken=response['NextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        sagemaker_domains_count += len(response['Domains'])
+
+    if sagemaker_domains_count > 0 or args.verbose_mode:
+        progress_print(resource_count=sagemaker_domains_count, resource_type='Serverless Containers [SageMaker Domains]', region=region, account=account['Name'])
+        totals['Serverless Containers'] += sagemaker_domains_count
+
+
+# Serverless Containers: SageMaker Endpoints
+
+
+def get_aws_sagemaker_endpoints(region, credentials, account):
+    """ Get AWS SageMaker Endpoints in the specified Account """
+    sagemaker_endpoints_count = 0
+    client = get_aws_client('sagemaker', region, credentials)
+    try:
+        response = client.list_endpoints()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        response = {}
+        error_print(ex, account['Id'])
+        return
+    sagemaker_endpoints_count += len(response['Endpoints'])
+    while 'NextToken' in response:
+        try:
+            response = client.list_endpoints(NextToken=response['NextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        sagemaker_endpoints_count += len(response['Endpoints'])
+
+    if sagemaker_endpoints_count > 0 or args.verbose_mode:
+        progress_print(resource_count=sagemaker_endpoints_count, resource_type='Serverless Containers [SageMaker Endpoints]', region=region, account=account['Name'])
+        totals['Serverless Containers'] += sagemaker_endpoints_count
+
+
+# Registry Container Images: ECR
+
+# Limits: 1000 container images per ECR repository
+# args.max_image_tags is already lower.
+
+
+def get_aws_ecr_images(region, credentials, account):
+    """ Get AWS ECR Images in the specified Account """
+    ecr_repositories = []
+    container_registry_images_count = 0
+    client = get_aws_client('ecr', region, credentials)
+    try:
+        response = client.describe_repositories()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    ecr_repositories.extend(response['repositories'])
+    while 'nextToken' in response:
+        try:
+            response = client.describe_repositories(nextToken=response['nextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        ecr_repositories.extend(response['repositories'])
+    for repository in ecr_repositories:
+        try:
+            response = client.list_images(repositoryName=repository['repositoryName'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        container_registry_images_count += min(args.max_image_tags, len(response['imageIds']))
+        while 'nextToken' in response:
+            try:
+                response = client.list_images(repositoryName=repository['repositoryName'], nextToken=response['nextToken'])
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                response = {}
+                error_print(ex, account['Id'])
+                continue
+            container_registry_images_count += min(args.max_image_tags, len(response['imageIds']))
+
+    if container_registry_images_count > 0 or args.verbose_mode:
+        progress_print(resource_count=container_registry_images_count, resource_type='Registry Container Images [ECR]', region=region, account=account['Name'])
+        totals['Registry Container Images'] += container_registry_images_count
+
+
+# Data Buckets: S3 Buckets
+
+# Limits: 10000 S3 Buckets per Account.
+
+
+def get_aws_s3_buckets(region, credentials, account):
+    """ Get AWS S3 Buckets in the specified Account """
+    buckets_count = 0
+    client = get_aws_client('s3', region, credentials)
+    try:
+        response = client.list_buckets()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    buckets_count += len(response['Buckets'])
+    while 'NextToken' in response:
+        try:
+            response = client.list_buckets(NextToken=response['NextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        buckets_count += len(response['Buckets'])
+    buckets_count = min(buckets_count, 10000)
+
+    if buckets_count > 0 or args.verbose_mode:
+        progress_print(resource_count=buckets_count, resource_type='Data Buckets [S3]', region=region, account=account['Name'])
+        totals['Data Buckets'] += buckets_count
+
+
+# Data in PaaS Databases (PaaS): DocumentDB
+
+
+def get_aws_docdb_clusters(region, credentials, account):
+    """ Get AWS DocumentDB Clusters in the specified Account """
+    database_clusters_count = 0
+    client = get_aws_client('docdb', region, credentials)
+    try:
+        response = client.describe_db_clusters()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    database_clusters_count += len(response['DBClusters'])
+    while 'Marker' in response:
+        try:
+            response = client.describe_db_instances(Marker=response['Marker'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        database_clusters_count += len(response['DBClusters'])
+
+    if database_clusters_count > 0 or args.verbose_mode:
+        progress_print(resource_count=database_clusters_count, resource_type='PaaS Databases [DocumentDB]', region=region, account=account['Name'])
+        totals['PaaS Databases'] += database_clusters_count
+
+
+# Data in PaaS Databases (PaaS): RDS Aurora (MySQL, PostgreSQL)
+
+
+def get_aws_rds_aurora_clusters(region, credentials, account):
+    """ Get AWS RDS Aurora Clusters in the specified Account """
+    database_clusters_count = 0
+    client = get_aws_client('rds', region, credentials)
+    filters = [
+        {'Name': 'engine', 'Values':
+            ['aurora-mysql', 'aurora-postgresql']
+        }
+    ]
+    try:
+        response = client.describe_db_clusters(Filters=filters)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    database_clusters_count += len(response['DBClusters'])
+    while 'Marker' in response:
+        try:
+            response = client.describe_db_clusters(Filters=filters, Marker=response['Marker'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        database_clusters_count += len(response['DBClusters'])
+
+    if database_clusters_count > 0 or args.verbose_mode:
+        progress_print(resource_count=database_clusters_count, resource_type='PaaS Databases [RDS Aurora]', region=region, account=account['Name'])
+        totals['PaaS Databases'] += database_clusters_count
+
+
+# Data in PaaS Databases (PaaS): RDS (MariaDB, MSSQL, MySQL, Oracle, PostgreSQL)
+
+
+def get_aws_rds_instances(region, credentials, account):
+    """ Get AWS RDS Instances in the specified Account """
+    database_instances_count = 0
+    client = get_aws_client('rds', region, credentials)
+    filters = [
+        {'Name': 'engine', 'Values':
+            ['mariadb', 'mysql', 'oracle-ee', 'oracle-ee-cdb', 'oracle-se2', 'oracle-se2-cdb', 'postgres', 'sqlserver-ee', 'sqlserver-ex', 'sqlserver-se', 'sqlserver-web']
+        }
+    ]
+    try:
+        response = client.describe_db_instances(Filters=filters)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    database_instances_count += len(response['DBInstances'])
+    while 'Marker' in response:
+        try:
+            response = client.describe_db_instances(Filters=filters, Marker=response['Marker'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        database_instances_count += len(response['DBInstances'])
+
+    if database_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=database_instances_count, resource_type='PaaS Databases [RDS]', region=region, account=account['Name'])
+        totals['PaaS Databases'] += database_instances_count
+
+
+# Data in PaaS Databases (PaaS): RedShift
+
+
+def get_aws_redshift_clusters(region, credentials, account):
+    """ Get AWS RedShift Clusters in the specified Account """
+    database_clusters_count = 0
+    client = get_aws_client('redshift', region, credentials)
+    try:
+        response = client.describe_clusters()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    database_clusters_count += len(response['Clusters'])
+    while 'Marker' in response:
+        try:
+            response = client.describe_clusters(Marker=response['Marker'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        database_clusters_count += len(response['Clusters'])
+
+    if database_clusters_count > 0 or args.verbose_mode:
+        progress_print(resource_count=database_clusters_count, resource_type='PaaS Databases [RedShift]', region=region, account=account['Name'])
+        totals['PaaS Databases'] += database_clusters_count
+
+
+# Data in Data Warehouses: DynamoDB
+
+# Limits: 1000 DynamoDBs Table per region per account.
+
+
+def get_aws_dynamodb_tables(region, credentials, account):
+    """ Get AWS DynamoDB Tables in the specified Account """
+    data_warehouses_count = 0
+    client = get_aws_client('dynamodb', region, credentials)
+    try:
+        response = client.list_tables()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, account['Id'])
+        return
+    data_warehouses_count += len(response['TableNames'])
+    while 'LastEvaluatedTableName' in response:
+        try:
+            response = client.list_tables(ExclusiveStartTableName=response['LastEvaluatedTableName'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        data_warehouses_count += len(response['TableNames'])
+    data_warehouses_count = min(data_warehouses_count, 10000)
+
+    if data_warehouses_count > 0 or args.verbose_mode:
+        progress_print(resource_count=data_warehouses_count, resource_type='Data Warehouses [DynamoDB]', region=region, account=account['Name'])
+        totals['Data Warehouses'] += data_warehouses_count
+
+
+# AI/LLM: Bedrock Custom Models
+
+
+def get_aws_bedrock_custom_models(region, credentials, account):
+    """ Get AWS Bedrock Custom Models in the specified Account and Region """
+    bedrock_custom_models_count = 0
+    client = get_aws_client('bedrock', region, credentials)
+    try:
+        response = client.list_custom_models()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        ex_str = str(ex)
+        if any(s in ex_str for s in ('EndpointResolutionError', 'UnknownEndpointError', 'UnknownOperationException', 'Unknown operation', 'Unknown Operation')):
+            return
+        error_print(ex, account['Id'])
+        return
+    bedrock_custom_models_count += len(response.get('modelSummaries', []))
+    while 'nextToken' in response:
+        try:
+            response = client.list_custom_models(nextToken=response['nextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        bedrock_custom_models_count += len(response.get('modelSummaries', []))
+
+    if bedrock_custom_models_count > 0 or args.verbose_mode:
+        progress_print(resource_count=bedrock_custom_models_count, resource_type='Bedrock Custom Models', region=region, account=account['Name'])
+        totals['Bedrock Custom Models'] += bedrock_custom_models_count
+
+
+# AI/LLM: Bedrock Agents
+
+
+def get_aws_bedrock_agents(region, credentials, account):
+    """ Get AWS Bedrock Agents in the specified Account and Region """
+    bedrock_agents_count = 0
+    client = get_aws_client('bedrock-agent', region, credentials)
+    try:
+        response = client.list_agents()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        ex_str = str(ex)
+        if any(s in ex_str for s in ('EndpointResolutionError', 'UnknownEndpointError', 'UnknownOperationException', 'Unknown operation', 'Unknown Operation')):
+            return
+        error_print(ex, account['Id'])
+        return
+    bedrock_agents_count += len(response.get('agentSummaries', []))
+    while 'nextToken' in response:
+        try:
+            response = client.list_agents(nextToken=response['nextToken'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            response = {}
+            error_print(ex, account['Id'])
+            continue
+        bedrock_agents_count += len(response.get('agentSummaries', []))
+
+    if bedrock_agents_count > 0 or args.verbose_mode:
+        progress_print(resource_count=bedrock_agents_count, resource_type='Bedrock Agents', region=region, account=account['Name'])
+        totals['Bedrock Agents'] += bedrock_agents_count
+
+
+####
+# Main
+####
+
+# pylint: disable=too-many-branches, too-many-statements
+def get_aws_resources(account, current_account_id, root_account_id):
+    """ Get countable resources """
+    exceptions = 0
+    credentials = aws_get_credentials(account['Id'], current_account_id, root_account_id)
+    verbose_print(f"credentials: {credentials}")
+    if not credentials:
+        print(f"Skipping {account['Id']} - {account['Name']}")
+        return
+    if args.input_regions:
+        regions = get_aws_regions_from_file()
+    else:
+        regions = get_aws_regions(credentials)
+    # Implement lightsail_regions as a subset of regions.
+    if regions:
+        lightsail_regions = get_aws_lightsail_region_names(credentials)
+    else:
+        lightsail_regions = []
+    # If debug mode is disabled (default), run all functions concurrently with multithreading.
+    # If debug mode is enabled, run all functions sequentially without multithreading.
+    if args.debug_mode:
+        # AWS APIs requiring a regional client.
+        for region in regions:
+            if enabled['Virtual Machines']:
+                get_aws_ec2_instances(region=region['RegionName'], credentials=credentials, account=account)
+                if region['RegionName'] in lightsail_regions:
+                    get_aws_lightsail_instances(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Container Hosts']:
+                get_aws_ecs_container_instances(region=region['RegionName'], credentials=credentials, account=account)
+                get_aws_eks_instances(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Serverless Functions']:
+                get_aws_lambda_functions(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Serverless Containers']:
+                get_aws_ecs_resources(region=region['RegionName'], credentials=credentials, account=account)
+                get_aws_sagemaker_domains(region=region['RegionName'], credentials=credentials, account=account)
+                get_aws_sagemaker_endpoints(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['PaaS Databases']:
+                get_aws_docdb_clusters(region=region['RegionName'], credentials=credentials, account=account)
+                get_aws_rds_aurora_clusters(region=region['RegionName'], credentials=credentials, account=account)
+                get_aws_rds_instances(region=region['RegionName'], credentials=credentials, account=account)
+                get_aws_redshift_clusters(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Data Warehouses']:
+                get_aws_dynamodb_tables(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Registry Container Images']:
+                get_aws_ecr_images(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Bedrock Custom Models']:
+                get_aws_bedrock_custom_models(region=region['RegionName'], credentials=credentials, account=account)
+            if enabled['Bedrock Agents']:
+                get_aws_bedrock_agents(region=region['RegionName'], credentials=credentials, account=account)
+        # S3 APIs using a global control plane, so we use the "default" partition region.
+        if enabled['Data Buckets']:
+            get_aws_s3_buckets(region=select_default_region(), credentials=credentials, account=account)
+    else:
+        futures = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            # AWS APIs requiring a regional client.
+            for region in regions:
+                if enabled['Virtual Machines']:
+                    futures.append(executor.submit(get_aws_ec2_instances, region=region['RegionName'], credentials=credentials, account=account))
+                    if region['RegionName'] in lightsail_regions:
+                        futures.append(executor.submit(get_aws_lightsail_instances, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Container Hosts']:
+                    futures.append(executor.submit(get_aws_ecs_container_instances, region=region['RegionName'], credentials=credentials, account=account))
+                    futures.append(executor.submit(get_aws_eks_instances, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Serverless Functions']:
+                    futures.append(executor.submit(get_aws_lambda_functions, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Serverless Containers']:
+                    futures.append(executor.submit(get_aws_ecs_resources, region=region['RegionName'], credentials=credentials, account=account))
+                    futures.append(executor.submit(get_aws_sagemaker_domains, region=region['RegionName'], credentials=credentials, account=account))
+                    futures.append(executor.submit(get_aws_sagemaker_endpoints, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['PaaS Databases']:
+                    futures.append(executor.submit(get_aws_docdb_clusters, region=region['RegionName'], credentials=credentials, account=account))
+                    futures.append(executor.submit(get_aws_rds_aurora_clusters, region=region['RegionName'], credentials=credentials, account=account))
+                    futures.append(executor.submit(get_aws_rds_instances, region=region['RegionName'], credentials=credentials, account=account))
+                    futures.append(executor.submit(get_aws_redshift_clusters, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Data Warehouses']:
+                    futures.append(executor.submit(get_aws_dynamodb_tables, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Registry Container Images']:
+                    futures.append(executor.submit(get_aws_ecr_images, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Bedrock Custom Models']:
+                    futures.append(executor.submit(get_aws_bedrock_custom_models, region=region['RegionName'], credentials=credentials, account=account))
+                if enabled['Bedrock Agents']:
+                    futures.append(executor.submit(get_aws_bedrock_agents, region=region['RegionName'], credentials=credentials, account=account))
+            # S3 APIs using a global control plane, so we use the "default" partition region.
+            if enabled['Data Buckets']:
+                futures.append(executor.submit(get_aws_s3_buckets, region=select_default_region(), credentials=credentials, account=account))
+        for future in concurrent.futures.as_completed(futures):
+            if future.exception():
+                exceptions += 1
+
+
+def output_results(accounts):
+    """ Output results """
+    # Summary File
+    with open(output_file, 'w', encoding='utf-8', newline='') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count'])
+        for resource_type, resource_count in totals.items():
+            csv_writer.writerow([resource_type, resource_count])
+    # Log File
+    with open(output_file_log, 'w', encoding='utf-8') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count', 'Account', 'Region'])
+        for item in totals_log:
+            csv_writer.writerow(item)
+
+    # Error File
+    if errors_log:
+        with open(error_log_file, 'w', encoding='utf-8') as err_file:
+            for error in errors_log:
+                err_file.write(error + "\n")
+
+    # Summary
+    print(f"\nResults across {len(accounts)} AWS Accounts (script version: {version})\n")
+
+    if enabled['Virtual Machines']:
+        print(f"{str(totals['Virtual Machines']).rjust(padding)} Virtual Machines [EC2, LightSail]")
+    if enabled['Container Hosts']:
+        print(f"{str(totals['Container Hosts']).rjust(padding)} Container Hosts [ECS, EKS]")
+    if enabled['Serverless Functions']:
+        print(f"{str(totals['Serverless Functions']).rjust(padding)} Serverless Functions [Lambda]")
+    if enabled['Serverless Containers']:
+        print(f"{str(totals['Serverless Containers']).rjust(padding)} Serverless Containers [ECS and EKS Fargate, SageMaker Domains, SageMaker Endpoints]")
+
+    if enabled['Data Buckets']:
+        print()
+        print(f"{str(totals['Data Buckets']).rjust(padding)} Data Buckets (Public and Private) [S3]")
+    if enabled['PaaS Databases']:
+        print(f"{str(totals['PaaS Databases']).rjust(padding)} PaaS Databases [DocumentDB, RDS, RedShift]")
+    if enabled['Data Warehouses']:
+        print(f"{str(totals['Data Warehouses']).rjust(padding)} Data Warehouses [DynamoDB]")
+
+    if enabled['Non-OS Disks']:
+        print()
+        print(f"{str(totals['Non-OS Disks']).rjust(padding)} Non-OS Disks [EC2, LightSail]")
+    if enabled['Registry Container Images']:
+        print(f"{str(totals['Registry Container Images']).rjust(padding)} Registry Container Images [ECR]")
+
+    if enabled['Bedrock Custom Models'] or enabled['Bedrock Agents']:
+        print()
+    if enabled['Bedrock Custom Models']:
+        print(f"{str(totals['Bedrock Custom Models']).rjust(padding)} Bedrock Custom Models")
+    if enabled['Bedrock Agents']:
+        print(f"{str(totals['Bedrock Agents']).rjust(padding)} Bedrock Agents")
+
+    if not args.data_mode:
+        print()
+        print("To count Data Security (Buckets, Databases, etc) resources, rerun with '--data'")
+    if not args.images_mode:
+        print()
+        print("To count Registry Container Images, rerun with '--images'")
+    if not args.ai_mode:
+        print()
+        print("To count AI/LLM resources, rerun with '--ai'")
+
+    print(f"\nDetails written to {output_file} and {output_file_log}")
+
+    if errors_log:
+        print("\nExceptions occurred.")
+        print(f"Review {error_log_file} or rerun with '--debug' to disable parallel processing and exit upon first error.")
+
+
+def main():
+    """ Calculon Compute! """
+    root_account_id = None
+
+    print("Getting the current AWS Account")
+    current_account = get_aws_account()
+    current_account_id = current_account['Account']
+    if current_account['Arn'].endswith('root'):
+        root_account_id = current_account['Account']
+    if current_account_id == root_account_id:
+        print(f"\nFound Management Account:\n-- {current_account_id} {current_account['Arn']}")
+    else:
+        print(f"\nFound Account:\n- {current_account_id}")
+
+    if args.all:
+        if current_account_id == root_account_id:
+            print(f"ERROR: The current AWS Account ({current_account['Arn']}) is a root account.")
+            print("Roles may not be assumed by root accounts, and AssumeRole is required to scan Organization Member Accounts.")
+            print("Exiting...")
+            sys.exit(1)
+        print("\nGetting AWS Accounts in the current AWS Organization")
+        org_root_account_id, accounts = get_aws_organization()
+        if org_root_account_id:
+            print(f"\nFound Management Account:\n-- {org_root_account_id}")
+        print(f"\nFound {len(accounts)} Accounts:")
+        for account in accounts:
+            print(f"-- {account['Id']} - {account['Name']}")
+        print('')
+
+    elif args.input_accounts:
+        if current_account_id == root_account_id:
+            print(f"ERROR: The current AWS Account ({current_account['Arn']}) is a root account.")
+            print("Roles may not be assumed by root accounts, and AssumeRole is required to scan other Accounts.")
+            print("Exiting...")
+            sys.exit(1)
+        print(f"\nGetting AWS Accounts from file: {accounts_file}")
+        accounts = get_aws_accounts_from_file()
+        print(f"\nFound {len(accounts)} Accounts:")
+
+    else:
+        if args.id:
+            if current_account_id == root_account_id and args.id != current_account_id:
+                print(f"ERROR: The current AWS Account ({current_account['Arn']}) is a root account.")
+                print("Roles may not be assumed by root accounts, and AssumeRole is required to scan other Accounts.")
+                print("Exiting...")
+                sys.exit(1)
+            print(f"\nGetting AWS Account: {args.id}")
+            accounts = [{'Id': args.id, 'Name': args.id}]
+            if root_account_id == args.id:
+                print(f"\nFound Management Account:\n-- {args.id}")
+        else:
+            accounts = [{'Id': current_account_id, 'Name': current_account_id}]
+
+    print("\nGetting Countable Resources for each AWS Account ...")
+    for account in accounts:
+        print(f"\nScanning {account['Id']} - {account['Name']}")
+        get_aws_resources(account, current_account_id, root_account_id)
+
+    output_results(accounts)
+
+
+####
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT,signal_handler)
+    main()

--- a/qlu-resource-discovery-tools/resource-count-azure-v2.py
+++ b/qlu-resource-discovery-tools/resource-count-azure-v2.py
@@ -1,0 +1,1210 @@
+#!/usr/bin/env python3
+
+# pylint: disable=invalid-name, too-many-lines
+
+""" Qualys : Resource Count : Azure """
+
+import argparse
+import concurrent.futures
+import csv
+import inspect
+import os
+import signal
+import subprocess
+import sys
+
+# As a single script download, we do not publish a requirements.txt. Autodocument.
+
+try:
+    import azure.mgmt.resourcegraph as az_rg
+    from azure.containerregistry import ContainerRegistryClient
+    from azure.identity import DefaultAzureCredential
+    from azure.mgmt.appcontainers import ContainerAppsAPIClient
+    from azure.mgmt.azurestackhci import AzureStackHCIClient
+    from azure.mgmt.compute import ComputeManagementClient
+    from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+    from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+    from azure.mgmt.containerservice import ContainerServiceClient
+    from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
+    from azure.mgmt.hybridcompute import HybridComputeManagementClient
+    from azure.mgmt.sql import SqlManagementClient
+    from azure.mgmt.storage import StorageManagementClient
+    from azure.mgmt.subscription import SubscriptionClient
+    from azure.mgmt.web import WebSiteManagementClient
+    # Retained for reference - was used for Data Plane container enumeration (blocked by firewalls)
+    # from azure.storage.blob import BlobServiceClient
+    from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD, AZURE_CHINA_CLOUD
+
+except ImportError:
+    print("\nERROR: Missing required Azure SDK packages. Run the following command to install/upgrade:\n")
+    print("""pip3 install --upgrade \\
+    azure-mgmt-resourcegraph \\
+    azure-containerregistry \\
+    azure-identity \\
+    azure-mgmt-appcontainers \\
+    azure-mgmt-azurestackhci \\
+    azure-mgmt-cognitiveservices \\
+    azure-mgmt-compute \\
+    azure-mgmt-containerinstance \\
+    azure-mgmt-containerregistry \\
+    azure-mgmt-containerservice \\
+    azure-mgmt-hybridcompute \\
+    azure-mgmt-sql \\
+    azure-mgmt-storage \\
+    azure-mgmt-subscription \\
+    azure-mgmt-web \\
+    azure-storage-blob \\
+    msrestazure
+""")
+    sys.exit(1)
+
+
+version='2.8.4'
+
+
+####
+# Command Line Arguments
+####
+
+
+DEFAULT_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+
+parser = argparse.ArgumentParser(description = 'Count Azure Resources')
+parser.add_argument(
+    '--all',
+    action = 'store_true',
+    dest = 'all',
+    help = 'Count resources in all Azure Subscriptions in the current Management Group (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--id',
+    dest = 'id',
+    help = 'Count resources in the specified Azure Subscription',
+    default = None
+)
+parser.add_argument(
+    '--subscriptions',
+    action = 'store_true',
+    dest = 'input_subscriptions',
+    help = 'Count resources in the list of Azure subscriptions (one ID per line) in a file named subscriptions.txt (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--data',
+    action = 'store_true',
+    dest = 'data_mode',
+    help = 'Count Qualys Cloud Data Security (Buckets, Databases, etc) resources (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--images',
+    action = 'store_true',
+    dest = 'images_mode',
+    help = 'Count Qualys Cloud Registry Container Images (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--ai',
+    action = 'store_true',
+    dest = 'ai_mode',
+    help = 'Count AI/LLM resources (AI Model Deployments) (default: disabled)',
+    default = False
+)
+pgroup = parser.add_mutually_exclusive_group()
+pgroup.add_argument(
+    '--china',
+    action = 'store_true',
+    dest = 'china_mode',
+    help = 'Enable AZURE_CHINA_CLOUD Mode (default: disabled)',
+)
+pgroup.add_argument(
+    '--germany',
+    action = 'store_true',
+    dest = 'ger_mode',
+    help = 'Enable (Experimental) AZURE_GERMAN_CLOUD Mode (default: disabled)',
+)
+pgroup.add_argument(
+    '--gov',
+    action = 'store_true',
+    dest = 'gov_mode',
+    help = 'Enable AZURE_US_GOV_CLOUD Mode (default: disabled)',
+)
+parser.add_argument(
+    '--graph',
+    action = 'store_true',
+    dest = 'graph_mode',
+    help = 'Enable (experimental) Azure Resource Graph Mode (default: disabled)',
+)
+parser.add_argument(
+    '--max-image-tags',
+    action = 'store',
+    dest = 'max_image_tags',
+    help = 'Number of image tags to count per registry image (default: 5, range 1 to 1000)',
+    type = int,
+    default = 5
+)
+parser.add_argument(
+    '--max-workers',
+    dest = 'max_workers',
+    help = f'Maximum parallel processing requests (default: {DEFAULT_MAX_WORKERS}, range 1 to 255)',
+    type = int,
+    default = DEFAULT_MAX_WORKERS
+)
+parser.add_argument(
+    '--debug',
+    action = 'store_true',
+    dest = 'debug_mode',
+    help = 'Disable parallel processing and exit upon first error (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--verbose',
+    action = 'store_true',
+    dest = 'verbose_mode',
+    help = 'Output verbose debugging information (default: disabled)',
+    default = False
+)
+args = parser.parse_args()
+
+if args.max_image_tags < 1 or args.max_image_tags > 1000:
+    print(f"ERROR: --max-image-tags {args.max_image_tags} out of range: [1 .. 1000]")
+    sys.exit(1)
+if args.max_workers < 1 or args.max_workers > 255:
+    print(f"ERROR: --max-workers {args.max_workers} out of range: [1 .. 255]")
+    sys.exit(1)
+
+
+####
+# Configuration and Globals
+####
+
+subscriptions_file   = 'subscriptions.txt'
+output_file          = 'azure-resources.csv'
+output_file_log      = 'azure-resources-log.csv'
+error_log_file       = 'azure-errors-log.txt'
+padding = 6
+sub_process_timeout  = 360
+
+# Map command-line arguments to counts to execute and display.
+enabled = {
+    'Virtual Machines':             True,
+    'Container Hosts':              True,
+    'Serverless Functions':         True,
+    'Serverless Containers':        True,
+    'Asset Metadata':               True,
+
+    'Data Buckets':                 args.data_mode,
+    'PaaS Databases':               args.data_mode,
+    'Data Warehouses':              args.data_mode,
+
+    'Non-OS Disks':                 True,
+
+    'Registry Container Images':    args.images_mode,
+
+    'AI Model Deployments':         args.ai_mode,
+    'AI Agents':                    args.ai_mode,
+
+}
+
+totals = {
+    'Virtual Machines':             0,
+    'Container Hosts':              0,
+    'Serverless Functions':         0,
+    'Serverless Containers':        0,
+    'Asset Metadata':               0,
+
+    'Data Buckets':                 0,
+    'PaaS Databases':               0,
+    'Data Warehouses':              0,
+
+    'Non-OS Disks':                 0,
+    'Registry Container Images':    0,
+
+    'AI Model Deployments':         0,
+    'AI Agents':                    0,
+
+}
+
+totals_log = []
+errors_log = []
+
+try:
+    if args.china_mode:
+        azure_credential        = DefaultAzureCredential(authority=AZURE_CHINA_CLOUD.endpoints.active_directory)
+        azure_base_url          = AZURE_CHINA_CLOUD.endpoints.resource_manager
+        azure_credential_scopes = [AZURE_CHINA_CLOUD.endpoints.resource_manager + '/.default']
+        azure_storage_endpoint  = AZURE_CHINA_CLOUD.suffixes.storage_endpoint
+    elif args.ger_mode:
+        azure_credential        = DefaultAzureCredential(authority=AZURE_GERMAN_CLOUD.endpoints.active_directory)
+        azure_base_url          = AZURE_GERMAN_CLOUD.endpoints.resource_manager
+        azure_credential_scopes = [AZURE_GERMAN_CLOUD.endpoints.resource_manager + '/.default']
+        azure_storage_endpoint  = AZURE_GERMAN_CLOUD.suffixes.storage_endpoint
+    elif args.gov_mode:
+        azure_credential        = DefaultAzureCredential(authority=AZURE_US_GOV_CLOUD.endpoints.active_directory)
+        azure_base_url          = AZURE_US_GOV_CLOUD.endpoints.resource_manager
+        azure_credential_scopes = [AZURE_US_GOV_CLOUD.endpoints.resource_manager + '/.default']
+        azure_storage_endpoint  = AZURE_US_GOV_CLOUD.suffixes.storage_endpoint
+    else:
+        azure_credential        = DefaultAzureCredential()
+        azure_base_url          = AZURE_PUBLIC_CLOUD.endpoints.resource_manager
+        azure_credential_scopes = [AZURE_PUBLIC_CLOUD.endpoints.resource_manager + '/.default']
+        azure_storage_endpoint  = AZURE_PUBLIC_CLOUD.suffixes.storage_endpoint
+except Exception as ex0:  # pylint: disable=broad-exception-caught
+    print("\nERROR: ")
+    print(ex0)
+    print("Unable to authenticate. Please verify your configuration")
+    sys.exit(0)
+
+
+####
+# Common Library Code
+####
+
+
+def signal_handler(_signal_received, _frame):
+    """ Control-C """
+    print("\nExiting")
+    sys.exit(0)
+
+
+def progress_print(resource_count, resource_type, subscription='', details=''):
+    """ Resource output """
+    rc = str(resource_count).rjust(padding)
+    # Split and join to remove multiple spaces when variables are empty.
+    print(' '.join(f"- {rc} {resource_type} in {subscription} {details}".split()))
+    totals_log.append([resource_type, resource_count, subscription])
+
+
+def verbose_print(details):
+    """ Verbose output """
+    if args.verbose_mode:
+        print(f"\nDEBUG: {details}")
+
+
+def error_print(details, subscription = ''):
+    """ Error output """
+    subscription  = f"Subscription: {subscription} " if subscription else ""
+    try:
+        function = f"{inspect.stack()[1].function}()"
+    except Exception:  # pylint: disable=broad-exception-caught
+        function = ''
+    try:
+        details = str(details).replace("\n", " ").replace("\r", " ")
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    print(f"\nERROR: {subscription}{function} {details}\n")
+    errors_log.append(f"ERROR: {subscription}{function} {details}")
+
+
+####
+# Customized Library Code
+####
+
+
+# pylint: disable=too-few-public-methods
+class obj():
+    """ Convert a dictionary to an object """
+    def __init__(self, d):
+        for k, v in d.items():
+            if isinstance(k, (list, tuple)):
+                setattr(self, k, [obj(x) if isinstance(x, dict) else x for x in v])
+            else:
+                setattr(self, k, obj(v) if isinstance(v, dict) else v)
+
+
+# Azure Resource Graph Query
+#
+# Example Result: {'total_records': 1, 'count': 1, 'result_truncated': 'false', 'data': [{'example': 9}], 'facets': []}
+
+
+def query_azure_resource_graph(subscription, query_string):
+    """ Query the Azure Resource Graph: ARG! """
+    result = []
+    try:
+        resource_graph_client = az_rg.ResourceGraphClient(credential=azure_credential, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        query_options = az_rg.models.QueryRequestOptions(skip_token=None)
+        if subscription:
+            query = az_rg.models.QueryRequest(subscriptions=[subscription.subscription_id], query=query_string, options=query_options)
+        else:
+            query = az_rg.models.QueryRequest(query=query_string, options=query_options)
+        results = resource_graph_client.resources(query).as_dict()
+        verbose_print(f"azure resource graph query: {query_string}")
+        verbose_print(f"azure resource graph query: total records: {results['total_records']} count: {results['count']} result truncated: {results['result_truncated']}")
+        result = results['data']
+        while 'skip_token' in results:
+            query_options = az_rg.models.QueryRequestOptions(skip_token=results['skip_token'])
+            if subscription:
+                query = az_rg.models.QueryRequest(subscriptions=[subscription.subscription_id], query=query_string, options=query_options)
+            else:
+                query = az_rg.models.QueryRequest(query=query_string, options=query_options)
+            results = resource_graph_client.resources(query).as_dict()
+            result.extend(results['data'])
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    return result
+
+
+def tag_in_tags(tag_key, tag_value, tags):
+    """ Check for tag key and value """
+    if not tags:
+        return False
+    return tags.get(tag_key) == tag_value
+
+
+# Arguments for libraries based on azure.core: retry_total: 10, retry_mode: 'exponential'.
+# Note that individual libraries aren't obligated to support any of these arguments.
+
+# We don't need to use nextLink with .list(), as the object returned by .list()
+# is an ItemPaged iterator that will use nextLink if we loop though the returned object.
+# If we want all resources in memory, we can use list(.list()).
+# Note that doing so could result in out-of-memory errors at scale.
+
+
+# Subscriptions (aka Azure Subscriptions)
+
+
+def get_azure_subscriptions():
+    """ Get Azure Subscriptions """
+    subscriptions = []
+
+    if args.graph_mode:
+        query = """
+        resourcecontainers
+        | where type == "microsoft.resources/subscriptions"
+        | order by name asc
+        | project id = subscriptionId, subscription_id = subscriptionId, display_name = name
+        """
+        result = query_azure_resource_graph(None, query)
+        for subscription in result:
+            subscription_object = obj(subscription)
+            subscriptions.append(subscription_object)
+            verbose_print(f"subscription: {subscription}")
+        return subscriptions
+
+    try:
+        subscription_client = SubscriptionClient(credential=azure_credential, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        # Wrapping .list() in list() to resolve the ItemPaged iterator and load all results.
+        subscriptions = list(subscription_client.subscriptions.list())
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting Azure Subscriptions.")
+    for subscription in subscriptions:
+        verbose_print(f"subscription: {subscription}")
+    return subscriptions
+
+
+def get_azure_subscriptions_from_file():
+    """ Get the list of Azure Subscriptions """
+    subscriptions = []
+    if os.path.isfile(subscriptions_file):
+        try:
+            with open(subscriptions_file, 'r', encoding='utf-8') as file:
+                for line in file:
+                    subscription_id = line.strip()
+                    # Verify the Subscription ID.
+                    if subscription_id and len(subscription_id) > 0:
+                        try:
+                            subscription = get_azure_subscription(subscription_id)[0]
+                            subscriptions.append(subscription)
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            print(f"Skipping invalid Azure Subscription ID from {subscriptions_file}: {subscription_id}")
+                    else:
+                        print(f"Skipping invalid Azure Subscription ID from {subscriptions_file}: {subscription_id}")
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex)
+            print("Error getting Azure Subscriptions from file.")
+            print("Exiting...")
+            sys.exit(1)
+    else:
+        print("Input file does not exist.")
+        print(f"Create a file named {subscriptions_file} and add each Azure Subscription ID to scan, one per line.")
+        print("Exiting...")
+        sys.exit(1)
+    return subscriptions
+
+
+def get_azure_subscription(subscription_id):
+    """ Get Azure Subscription """
+    subscriptions = []
+    try:
+        subscription_client = SubscriptionClient(credential=azure_credential, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        subscription = subscription_client.subscriptions.get(subscription_id)
+        subscriptions.append(subscription)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription_id)
+    for subscription in subscriptions:
+        verbose_print(f"subscription: {subscription}")
+    return subscriptions
+
+
+# Virtual Machines: Compute VMs
+
+
+def get_azure_vms(subscription):
+    """ Get Azure VMs in the specified Azure Subscription """
+    virtual_machines = []
+    virtual_machines_count = 0
+    non_os_disks_count = 0
+    linux_instances_count = 0
+
+    if args.graph_mode:
+        query = """
+        resources
+        | where type == "microsoft.compute/virtualmachines"
+        | where tags.Vendor != 'Databricks'
+        | summarize count()
+        """
+        result = query_azure_resource_graph(subscription, query)
+        virtual_machines_count = result[0]['count_']
+        query = """
+        resources
+        | where type == "microsoft.compute/virtualmachines"
+        | where tags.Vendor != 'Databricks'
+        | project non_os_disks_count = iff(isnotempty(properties.storageProfile.dataDisks), array_length(properties.storageProfile.dataDisks), 0)
+        | summarize sum(non_os_disks_count)
+        """
+        result = query_azure_resource_graph(subscription, query)
+        non_os_disks_count = result[0]['sum_non_os_disks_count']
+        if virtual_machines_count > 0 or args.verbose_mode:
+            progress_print(resource_count=virtual_machines_count, resource_type='Virtual Machines [Compute]', subscription=subscription.display_name, details=f"with {non_os_disks_count} Non-OS Disks")
+            totals['Virtual Machines'] += virtual_machines_count
+            totals['Non-OS Disks'] += non_os_disks_count
+        return
+
+    try:
+        compute_management_client = ComputeManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        virtual_machines = compute_management_client.virtual_machines.list_all()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for virtual_machine in virtual_machines:
+        verbose_print(f"virtual_machine: {virtual_machine}")
+        if virtual_machine.virtual_machine_scale_set:
+            continue
+        if tag_in_tags('Vendor', 'Databricks', virtual_machine.tags):
+            verbose_print(f"Skipping Databricks virtual_machine: {virtual_machine.tags}")
+            continue
+        virtual_machines_count += 1
+        if virtual_machine.os_profile and virtual_machine.os_profile.linux_configuration:
+            linux_instances_count += 1
+        if virtual_machine.storage_profile:
+            if virtual_machine.storage_profile.data_disks:
+                non_os_disks_count += len(virtual_machine.storage_profile.data_disks)
+
+    if virtual_machines_count > 0 or args.verbose_mode:
+        progress_print(resource_count=virtual_machines_count, resource_type='Virtual Machines [Compute]', subscription=subscription.display_name, details=f"with {non_os_disks_count} Non-OS Disks")
+        totals['Virtual Machines'] += virtual_machines_count
+        totals['Non-OS Disks'] += non_os_disks_count
+
+
+# Virtual Machines: Scale Set VMs (Add Graph Mode Query)
+
+# pylint: disable=too-many-locals
+def get_azure_vms_scale_sets(subscription):
+    """ Get Azure Scale Set VMs in the specified Azure Subscription """
+    virtual_machines = []
+    virtual_machines_count = 0
+    non_os_disks_count = 0
+    linux_instances_count = 0
+
+    try:
+        compute_management_client = ComputeManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        scale_sets = compute_management_client.virtual_machine_scale_sets.list_all()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for scale_set in scale_sets:
+        verbose_print(f"scale_set: {scale_set}")
+        scale_set_resource_group_name = scale_set.id.split('/')[4]
+        scale_set_non_os_disks_per_virtual_machine = 0
+        scale_set_virtual_machines_count = 0
+        scale_set_non_os_disks_count = 0
+        if scale_set.virtual_machine_profile:
+            if scale_set.virtual_machine_profile.storage_profile:
+                if scale_set.virtual_machine_profile.storage_profile.data_disks:
+                    scale_set_non_os_disks_per_virtual_machine = len(scale_set.virtual_machine_profile.storage_profile.data_disks)
+        try:
+            virtual_machines = compute_management_client.virtual_machine_scale_set_vms.list(resource_group_name=scale_set_resource_group_name, virtual_machine_scale_set_name=scale_set.name)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, subscription.display_name)
+        # Loop through the ItemPaged response.
+        for virtual_machine in virtual_machines:
+            verbose_print(f"virtual_machine: {virtual_machine}")
+            if tag_in_tags('Vendor', 'Databricks', virtual_machine.tags):
+                verbose_print(f"Skipping Databricks virtual_machine: {virtual_machine.tags}")
+                continue
+            scale_set_virtual_machines_count += 1
+            virtual_machines_count += 1
+            if virtual_machine.os_profile and virtual_machine.os_profile.linux_configuration:
+                linux_instances_count += 1
+            if not scale_set.virtual_machine_profile:
+                # No Virtual Machine / Scaling Profile: Virtual Machine manually attached after Scale Set deployment.
+                virtual_machine_non_os_disks_count = 0
+                try:
+                    virtual_machine_detail = compute_management_client.virtual_machines.get(resource_group_name=scale_set_resource_group_name, vm_name=virtual_machine.name)
+                    verbose_print(f"virtual_machine_detail: {virtual_machine_detail}")
+                    if virtual_machine_detail.storage_profile:
+                        if virtual_machine_detail.storage_profile.data_disks:
+                            virtual_machine_non_os_disks_count = len(virtual_machine_detail.storage_profile.data_disks)
+                except Exception as ex:  # pylint: disable=broad-exception-caught
+                    error_print(ex, subscription.display_name)
+                scale_set_non_os_disks_count += virtual_machine_non_os_disks_count
+        if scale_set.virtual_machine_profile:
+            scale_set_non_os_disks_count = scale_set_non_os_disks_per_virtual_machine * scale_set_virtual_machines_count
+        non_os_disks_count += scale_set_non_os_disks_count
+
+    if virtual_machines_count > 0 or args.verbose_mode:
+        progress_print(resource_count=virtual_machines_count, resource_type='Virtual Machines [Scale Sets]', subscription=subscription.display_name, details=f"with {non_os_disks_count} Non-OS Disks")
+        totals['Virtual Machines'] += virtual_machines_count
+        totals['Non-OS Disks'] += non_os_disks_count
+        totals['Virtual Machine Agents'] += linux_instances_count
+
+
+# Container Hosts: AKS
+
+
+def get_azure_aks_container_instances(subscription):
+    """ Get Azure AKS Hosts in the specified Azure Subscription """
+    managed_clusters = []
+    aks_instances_count = 0
+
+    if args.graph_mode:
+        query = """
+        resources
+        | where type == "microsoft.containerservice/managedclusters"
+        | project aks_instances_count = iff(isnotempty(properties.agentPoolProfiles[0]), properties.agentPoolProfiles[0].["count"], 0)
+        | summarize sum(aks_instances_count)
+        """
+        result = query_azure_resource_graph(subscription, query)
+        aks_instances_count = result[0]['sum_aks_instances_count']
+        if aks_instances_count > 0 or args.verbose_mode:
+            progress_print(resource_count=aks_instances_count, resource_type='Container Hosts [AKS]', subscription=subscription.display_name)
+            totals['Container Hosts'] += aks_instances_count
+        return
+
+    try:
+        container_service_client = ContainerServiceClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        managed_clusters = container_service_client.managed_clusters.list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for managed_cluster in managed_clusters:
+        verbose_print(f"managed_cluster: {managed_cluster}")
+        aks_instances_count += managed_cluster.agent_pool_profiles[0].count
+
+    if aks_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=aks_instances_count, resource_type='Container Hosts', subscription=subscription.display_name)
+        totals['Container Hosts'] += aks_instances_count
+
+
+# Serverless Containers: Azure Container Instances (ACI)
+
+
+def get_azure_container_instances(subscription):
+    """ Get Azure Container Instances in the specified Azure Subscription """
+    container_instances = []
+    container_instances_count = 0
+    try:
+        container_instances_client = ContainerInstanceManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        container_instances = container_instances_client.container_groups.list()
+
+        for container_instance in container_instances:
+            verbose_print(f"container_instance: {container_instance}")
+            container_instances_count += 1
+
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+
+    if container_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=container_instances_count, resource_type='Serverless Containers [Azure Container Instances]', subscription=subscription.display_name)
+        totals['Serverless Containers'] += container_instances_count
+
+
+# Serverless Containers: Azure Container Apps
+
+
+def get_azure_container_apps(subscription):
+    """ Get Azure Container Apps in the specified Azure Subscription """
+    container_apps = []
+    container_apps_count = 0
+    try:
+        container_apps_client = ContainerAppsAPIClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        container_apps = container_apps_client.container_apps.list_by_subscription()
+
+        for container_app in container_apps:
+            verbose_print(f"container_app: {container_app}")
+            container_apps_count += 1
+
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+
+    if container_apps_count > 0 or args.verbose_mode:
+        progress_print(resource_count=container_apps_count, resource_type='Serverless Containers [Azure Container Apps]', subscription=subscription.display_name)
+        totals['Serverless Containers'] += container_apps_count
+
+
+# Serverless Functions: Web Apps
+
+
+def get_azure_functions_web_apps(subscription):
+    """ Get Azure Functions in the specified Azure Subscription """
+    serverless_functions = []
+    serverless_functions_count = 0
+
+    if args.graph_mode:
+        query = """
+        resources
+        | where type == "microsoft.web/sites"
+        | summarize count()
+        """
+        result = query_azure_resource_graph(subscription, query)
+        serverless_functions_count += result[0]['count_']
+        query = """
+        resources
+        | where type == "microsoft.web/staticsites"
+        | summarize count()
+        """
+        result = query_azure_resource_graph(subscription, query)
+        serverless_functions_count += result[0]['count_']
+        if serverless_functions_count > 0 or args.verbose_mode:
+            progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [Web Apps]', subscription=subscription.display_name)
+            totals['Serverless Functions'] += serverless_functions_count
+        return
+
+    try:
+        web_site_management_client = WebSiteManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        web_apps = web_site_management_client.web_apps.list()
+        for web_app in web_apps:
+            serverless_functions_count += 1
+            if 'functionapp' not in web_app.kind:
+                continue
+            child_functions = web_site_management_client.web_apps.list_functions(web_app.resource_group, web_app.name)
+            # pylint: disable=unused-variable
+            for function in child_functions:
+                serverless_functions_count += 1
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for serverless_function in serverless_functions:
+        verbose_print(f"serverless_function: {serverless_function}")
+        serverless_functions_count += 1
+
+    if serverless_functions_count > 0 or args.verbose_mode:
+        progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [Web Apps]', subscription=subscription.display_name)
+        totals['Serverless Functions'] += serverless_functions_count
+
+
+# Serverless Functions: App Service Plans (Disabled: Double counts Web Apps)
+
+
+def get_azure_functions_web_apps_app_service_plans(subscription):
+    """ Get Azure App Services in the specified Azure Subscription """
+    serverless_functions = []
+    serverless_functions_count = 0
+
+    if args.graph_mode:
+        query = """
+        resources
+        | where type == "microsoft.web/serverfarms"
+        | summarize count()
+        """
+        result = query_azure_resource_graph(subscription, query)
+        serverless_functions_count = result[0]['count_']
+        if serverless_functions_count > 0 or args.verbose_mode:
+            progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [App Service Plans]', subscription=subscription.display_name)
+            totals['App Service Plan Serverless Functions'] += serverless_functions_count
+        return
+
+    try:
+        web_site_management_client = WebSiteManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        serverless_functions = web_site_management_client.app_service_plans.list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for serverless_function in serverless_functions:
+        verbose_print(f"serverless_function: {serverless_function}")
+        serverless_functions_count += 1
+
+    if serverless_functions_count > 0 or args.verbose_mode:
+        progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [App Service Plans]', subscription=subscription.display_name)
+        totals['Serverless Functions'] += serverless_functions_count
+
+
+# Registry Container Images: ACR
+
+# Limits: 1000 Container Images per ACR Repository
+# args.max_image_tags is already lower.
+
+
+# pylint: disable=too-many-statements
+def get_azure_acr_images(subscription):
+    """ Get Azure Registry Container Images in the specified Azure Subscription """
+    # https://github.com/Azure/azure-sdk-for-python/blob/azure-containerregistry_1.0.0b2/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registr>
+    container_registry_images_count = 0
+
+    # Avoid "Audience https://containerregistry.azure.net is not a supported MSI token audience" error, specific to Azure CloudShell.
+    if os.environ.get('AZD_IN_CLOUDSHELL'):
+        # Use an Azure Resource Graph query to minimize the use of subprocesses.
+        # registries = subprocess.check_output('az acr list --query "[].{name:name}" --output tsv', shell=True, text=True, timeout=sub_process_timeout)
+        query = """
+        resources
+        | where type == "microsoft.containerregistry/registries"
+        | project name
+        """
+        registries = query_azure_resource_graph(subscription, query)
+        for r, registry in enumerate(registries):
+            registries[r] = registry['name']
+        for registry in registries:
+            verbose_print(f"registry: {registry}")
+            try:
+                repositories = subprocess.check_output(f'az acr repository list --name {registry} --output tsv', shell=True, text=True, timeout=sub_process_timeout)
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                error_print(ex, subscription.display_name)
+                continue
+            for repository in repositories.splitlines():
+                verbose_print(f"repository: {repository}")
+                try:
+                    tags = subprocess.check_output(f'az acr repository show-tags --name {registry} --repository {repository} --query "length(@)" --output tsv', shell=True, text=True, timeout=sub_process_timeout)
+                except Exception as ex:  # pylint: disable=broad-exception-caught
+                    error_print(ex, subscription.display_name)
+                    continue
+                tags_count = max(1, int(tags))
+                container_registry_images_count += min(args.max_image_tags, tags_count)
+
+        if container_registry_images_count > 0 or args.verbose_mode:
+            progress_print(resource_count=container_registry_images_count, resource_type='Registry Container Images [ACR]', subscription=subscription.display_name)
+            totals['Registry Container Images'] += container_registry_images_count
+        return
+
+    try:
+        registry_management_client = ContainerRegistryManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        registries = registry_management_client.registries.list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for registry in registries:
+        verbose_print(f"registry: {registry}")
+        try:
+            endpoint = registry.login_server
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, subscription.display_name)
+            continue # next registry loop
+        try:
+            registry_client = ContainerRegistryClient(endpoint, azure_credential)
+            repositories = registry_client.list_repository_names()
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, subscription.display_name)
+            continue  # next registry loop
+        # Loop through the ItemPaged response.
+        for repository in repositories:
+            verbose_print(f"repository: {repository}")
+            try:
+                repository_properties = registry_client.get_repository_properties(repository)
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                error_print(ex, subscription.display_name)
+                continue  # next repository in registry loop
+            container_registry_images_count += min(args.max_image_tags, repository_properties.tag_count)
+
+    if container_registry_images_count > 0 or args.verbose_mode:
+        progress_print(resource_count=container_registry_images_count, resource_type='Registry Container Images [ACR]', subscription=subscription.display_name)
+        totals['Registry Container Images'] += container_registry_images_count
+
+
+# Data Buckets: Storage Containers
+
+# Limits: 10000 Blob Storage Containers per Storage Account
+
+
+def get_azure_storage_containers(subscription):
+    """ Get Azure Storage Containers in the specified Azure Subscription """
+    accounts = []
+    bucket_count = 0
+
+    try:
+        storage_management_client = StorageManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        accounts = storage_management_client.storage_accounts.list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for account in accounts:
+        verbose_print(f"account: {account}")
+        if tag_in_tags('application', 'Databricks', account.tags):
+            verbose_print(f"Skipping Databricks storage_account: {account.tags}")
+            continue
+        if tag_in_tags('databricks-environment', 'true', account.tags):
+            verbose_print(f"Skipping Databricks storage_account: {account.tags}")
+            continue
+        # Extract resource group from account ID
+        # Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{name}
+        resource_group_name = account.id.split('/')[4]
+        containers = []
+        try:
+            # Use Control Plane (ARM) to list containers - bypasses storage account firewall
+            containers = storage_management_client.blob_containers.list(
+                resource_group_name=resource_group_name,
+                account_name=account.name
+            )
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, subscription.display_name)
+        container_count = 0
+        # Loop through the ItemPaged response.
+        for container in containers:
+            verbose_print(f"container: {container}")
+            if container_count > 10000:
+                break
+            container_count += 1
+            bucket_count += 1
+
+    if bucket_count > 0 or args.verbose_mode:
+        progress_print(resource_count=bucket_count, resource_type='Data Buckets [Storage Containers]', subscription=subscription.display_name)
+        totals['Data Buckets'] += bucket_count
+
+
+# Data in PaaS Databases: Azure SQL
+
+
+def get_azure_sql_servers(subscription):
+    """ Get Azure SQL Servers in the specified Azure Subscription """
+    sql_servers = []
+    sql_databases = []
+    sql_databases_count = 0
+
+    if args.graph_mode:
+        query = """
+        resources
+        | where type == "microsoft.sql/servers/databases"
+        | summarize count()
+        """
+        result = query_azure_resource_graph(subscription, query)
+        sql_databases_count = result[0]['count_']
+        if sql_databases_count > 0 or args.verbose_mode:
+            progress_print(resource_count=sql_databases_count, resource_type='PaaS Databases [SQL]', subscription=subscription.display_name)
+            totals['PaaS Databases'] += sql_databases_count
+        return
+
+    try:
+        sql_management_client = SqlManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        sql_servers = sql_management_client.servers.list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for sql_server in sql_servers:
+        verbose_print(f"sql_server: {sql_server}")
+        resource_group = sql_server.id.split('/')[4]
+        try:
+            sql_databases = sql_management_client.databases.list_by_server(resource_group, sql_server.name)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, subscription.display_name)
+        # Loop through the ItemPaged response.
+        for sql_database in sql_databases:
+            verbose_print(f"sql_database: {sql_database}")
+            if sql_database.name == 'master':
+                continue
+            sql_databases_count += 1
+
+    if sql_databases_count > 0 or args.verbose_mode:
+        progress_print(resource_count=sql_databases_count, resource_type='PaaS Databases [SQL]', subscription=subscription.display_name)
+        totals['PaaS Databases'] += sql_databases_count
+
+
+# Asset Metadata: Azure Arc Machines
+# https://learn.microsoft.com/en-us/rest/api/hybridcompute/machines/list-by-subscription
+
+
+def get_azure_arc_machines(subscription):
+    """ Get Azure Arc Machines in the specified Azure Subscription """
+    machines = []
+    machines_count = 0
+
+    try:
+        hybrid_compute_managementClient = HybridComputeManagementClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        machines = hybrid_compute_managementClient.machines.list_by_subscription()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for machine in machines:
+        verbose_print(f"machine: {machine}")
+        machines_count += 1
+
+    if machines_count > 0 or args.verbose_mode:
+        progress_print(resource_count=machines_count, resource_type='Asset Metadata [Arc Machines]', subscription=subscription.display_name)
+        totals['Asset Metadata'] += machines_count
+
+
+# Asset Metadata: Azure Stack HCI Clusters
+# https://learn.microsoft.com/en-us/rest/api/stackhci/clusters/list-by-subscription
+
+
+def get_azure_stack_hci_clusters(subscription):
+    """ Get Azure Stack HCI Clusters in the specified Azure Subscription """
+    clusters = []
+    clusters_count = 0
+
+    try:
+        stack_hci_client = AzureStackHCIClient(azure_credential, subscription.subscription_id, base_url=azure_base_url, credential_scopes=azure_credential_scopes)
+        clusters = stack_hci_client.clusters.list_by_subscription()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+    # Loop through the ItemPaged response.
+    for cluster in clusters:
+        verbose_print(f"cluster: {cluster}")
+        clusters_count += 1
+
+    if clusters_count > 0 or args.verbose_mode:
+        progress_print(resource_count=clusters_count, resource_type='Asset Metadata [Stack HCI Clusters]', subscription=subscription.display_name)
+        totals['Asset Metadata'] += clusters_count
+
+
+# AI/LLM: Azure AI Model Deployments (Cognitive Services / OpenAI)
+
+
+def get_azure_ai_model_deployments(subscription):
+    """ Get Azure AI Model Deployments (OpenAI accounts) in the specified Azure Subscription """
+    ai_model_deployments_count = 0
+    try:
+        cognitive_services_client = CognitiveServicesManagementClient(azure_credential, subscription.subscription_id)
+        accounts = cognitive_services_client.accounts.list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+        return
+    for account in accounts:
+        verbose_print(f"cognitive_services_account: {account}")
+        if account.kind not in ('OpenAI', 'AIServices'):
+            continue
+        resource_group = account.id.split('/')[4]
+        try:
+            deployments = cognitive_services_client.deployments.list(resource_group, account.name)
+            for deployment in deployments:
+                verbose_print(f"ai_deployment: {deployment}")
+                ai_model_deployments_count += 1
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, subscription.display_name)
+
+    if ai_model_deployments_count > 0 or args.verbose_mode:
+        progress_print(resource_count=ai_model_deployments_count, resource_type='AI Model Deployments', subscription=subscription.display_name)
+        totals['AI Model Deployments'] += ai_model_deployments_count
+
+
+def get_azure_ai_agents(subscription):
+    """ Get Azure AI Agents in the specified Azure Subscription """
+    from azure.ai.agents import AgentsClient
+    from azure.ai.projects import AIProjectClient
+    ai_agents_count = 0
+    try:
+        cognitive_services_client = CognitiveServicesManagementClient(azure_credential, subscription.subscription_id)
+        accounts = list(cognitive_services_client.accounts.list())
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, subscription.display_name)
+        return
+    for account in accounts:
+        if account.kind not in ('OpenAI', 'AIServices'):
+            continue
+        foundry_ep = (account.properties.endpoints or {}).get('AI Foundry API', '')
+        if not foundry_ep:
+            continue
+        projects = account.properties.associated_projects or [account.name]
+        for project in projects:
+            proj_endpoint = f"{foundry_ep.rstrip('/')}/api/projects/{project}"
+            try:
+                # OpenAI Assistants format agents (asst_xxx IDs)
+                agents_client = AgentsClient(endpoint=proj_endpoint, credential=azure_credential)
+                asst_count = sum(1 for _ in agents_client.list_agents())
+                verbose_print(f"ai_agents (assistants) account={account.name} project={project} count={asst_count}")
+                ai_agents_count += asst_count
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                verbose_print(f"AgentsClient error account={account.name} project={project}: {ex}")
+            try:
+                # AI Foundry template agents (newer format)
+                proj_client = AIProjectClient(endpoint=proj_endpoint, credential=azure_credential)
+                foundry_count = sum(1 for _ in proj_client.agents.list())
+                verbose_print(f"ai_agents (foundry) account={account.name} project={project} count={foundry_count}")
+                ai_agents_count += foundry_count
+            except Exception as ex:  # pylint: disable=broad-exception-caught
+                verbose_print(f"AIProjectClient error account={account.name} project={project}: {ex}")
+    if ai_agents_count > 0 or args.verbose_mode:
+        progress_print(resource_count=ai_agents_count, resource_type='AI Agents [OpenAI Assistants]', subscription=subscription.display_name)
+        totals['AI Agents'] += ai_agents_count
+
+
+####
+# Main
+####
+
+
+def get_azure_resources(subscription):
+    """ Get countable resources """
+    exceptions = 0
+    # If debug mode is disabled (default), run all functions concurrently with multithreading.
+    # If debug mode is enabled, run all functions sequentially without multithreading.
+    if args.debug_mode:
+        if enabled['Virtual Machines']:
+            get_azure_vms(subscription)
+            get_azure_vms_scale_sets(subscription)
+        if enabled['Container Hosts']:
+            get_azure_aks_container_instances(subscription)
+        if enabled['Serverless Functions']:
+            get_azure_functions_web_apps(subscription)
+        if enabled['Serverless Containers']:
+            get_azure_container_instances(subscription)
+            get_azure_container_apps(subscription)
+        if enabled['Asset Metadata']:
+            get_azure_arc_machines(subscription)
+            get_azure_stack_hci_clusters(subscription)
+        if enabled['Data Buckets']:
+            get_azure_storage_containers(subscription)
+        if enabled['PaaS Databases']:
+            get_azure_sql_servers(subscription)
+        if enabled['Registry Container Images']:
+            get_azure_acr_images(subscription)
+        if enabled['AI Model Deployments']:
+            get_azure_ai_model_deployments(subscription)
+        if enabled['AI Agents']:
+            get_azure_ai_agents(subscription)
+    else:
+        futures = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            if enabled['Virtual Machines']:
+                futures.append(executor.submit(get_azure_vms, subscription))
+                futures.append(executor.submit(get_azure_vms_scale_sets, subscription))
+            if enabled['Container Hosts']:
+                futures.append(executor.submit(get_azure_aks_container_instances, subscription))
+            if enabled['Serverless Functions']:
+                futures.append(executor.submit(get_azure_functions_web_apps, subscription))
+            if enabled['Serverless Containers']:
+                futures.append(executor.submit(get_azure_container_instances, subscription))
+                futures.append(executor.submit(get_azure_container_apps, subscription))
+            if enabled['Asset Metadata']:
+                futures.append(executor.submit(get_azure_arc_machines, subscription))
+                futures.append(executor.submit(get_azure_stack_hci_clusters, subscription))
+            if enabled['Data Buckets']:
+                futures.append(executor.submit(get_azure_storage_containers, subscription))
+            if enabled['PaaS Databases']:
+                futures.append(executor.submit(get_azure_sql_servers, subscription))
+            if enabled['Registry Container Images']:
+                futures.append(executor.submit(get_azure_acr_images, subscription))
+            if enabled['AI Model Deployments']:
+                futures.append(executor.submit(get_azure_ai_model_deployments, subscription))
+            if enabled['AI Agents']:
+                futures.append(executor.submit(get_azure_ai_agents, subscription))
+        for future in concurrent.futures.as_completed(futures):
+            if future.exception():
+                exceptions += 1
+
+
+def output_results(subscriptions):
+    """ Output results """
+    # Summary File
+    with open(output_file, 'w', encoding='utf-8', newline='') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count'])
+        for resource_type, resource_count in totals.items():
+            csv_writer.writerow([resource_type, resource_count])
+    # Log File
+    with open(output_file_log, 'w', encoding='utf-8') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count', 'Subscription'])
+        for item in totals_log:
+            csv_writer.writerow(item)
+
+    # Error File
+    if errors_log:
+        with open(error_log_file, 'w', encoding='utf-8') as err_file:
+            for error in errors_log:
+                err_file.write(error + "\n")
+
+    # Summary
+    print(f"\nResults across {len(subscriptions)} Azure Subscriptions (script version: {version})\n")
+
+    if enabled['Virtual Machines']:
+        print(f"{str(totals['Virtual Machines']).rjust(padding)} Virtual Machines [Compute, Scale Sets]")
+    if enabled['Container Hosts']:
+        print(f"{str(totals['Container Hosts']).rjust(padding)} Container Hosts [AKS]")
+    if enabled['Serverless Functions']:
+        print(f"{str(totals['Serverless Functions']).rjust(padding)} Serverless Functions [Web Apps]")
+    if enabled['Serverless Containers']:
+        print(f"{str(totals['Serverless Containers']).rjust(padding)} Serverless Containers [Container Instances, Container Apps]")
+    if enabled['Asset Metadata']:
+        print(f"{str(totals['Asset Metadata']).rjust(padding)} Asset Metadata [Arc Machines, Stack HCI Clusters]")
+
+    if enabled['Data Buckets']:
+        print()
+        print(f"{str(totals['Data Buckets']).rjust(padding)} Data Buckets (Public and Private) [Storage Containers]")
+    if enabled['PaaS Databases']:
+        print(f"{str(totals['PaaS Databases']).rjust(padding)} PaaS Databases [SQL]")
+
+    if enabled['Non-OS Disks']:
+        print()
+        print(f"{str(totals['Non-OS Disks']).rjust(padding)} Non-OS Disks [Compute]")
+    if enabled['Registry Container Images']:
+        print()
+        print(f"{str(totals['Registry Container Images']).rjust(padding)} Registry Container Images [ACR]")
+
+    if enabled['AI Model Deployments'] or enabled['AI Agents']:
+        print()
+    if enabled['AI Model Deployments']:
+        print(f"{str(totals['AI Model Deployments']).rjust(padding)} AI Model Deployments [Azure AI Foundry, OpenAI]")
+    if enabled['AI Agents']:
+        print(f"{str(totals['AI Agents']).rjust(padding)} AI Agents [OpenAI Assistants]")
+
+    if not args.data_mode:
+        print()
+        print("To count Data Security (Buckets, Databases, etc) resources, rerun with '--data'")
+    if not args.images_mode:
+        print()
+        print("To count Registry Container Images, rerun with '--images'")
+    if not args.ai_mode:
+        print()
+        print("To count AI/LLM resources, rerun with '--ai'")
+
+    print(f"\nDetails written to {output_file} and {output_file_log}")
+
+    if errors_log:
+        print("\nExceptions occurred.")
+        print(f"Review {error_log_file} or rerun with '--debug' to disable parallel processing and exit upon error.")
+
+
+def main():
+    """ Calculon Compute! """
+    subscriptions = []
+
+    if args.all:
+        print("Getting Azure Subscriptions")
+        subscriptions = get_azure_subscriptions()
+        print(f"\nFound {len(subscriptions)} Azure Subscription(s)")
+        for subscription in subscriptions:
+            subscription_id = subscription.id.rsplit('/', 1)[-1]
+            print(f"-- {subscription_id} - {subscription.display_name}")
+        print('')
+    elif args.input_subscriptions:
+        subscriptions = get_azure_subscriptions_from_file()
+        print(f"\nFound {len(subscriptions)} Subscriptions:")
+    else:
+        if args.id:
+            print(f"\nGetting Azure Subscription {args.id}")
+            subscription_id = args.id
+        else:
+            subscription_id = input("Enter the Azure Subscription ID to scan: ")
+            print('')
+        subscriptions = get_azure_subscription(subscription_id)
+
+    if not subscriptions:
+        print("No Subscriptions found.")
+        print("Exiting...")
+        sys.exit(1)
+
+    print("\nGetting Countable Resources for each Azure Subscription ...")
+    for subscription in subscriptions:
+        if subscription.display_name == 'Access to Azure Active Directory':
+            # print(f"\nSkipping {subscription.display_name} (Classic Azure Portal Legacy Subscription) ...")
+            continue
+        subscription_id = subscription.id.rsplit('/', 1)[-1]
+        print(f"\nScanning {subscription_id} - {subscription.display_name} ...")
+        get_azure_resources(subscription)
+
+    output_results(subscriptions)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT,signal_handler)
+    main()

--- a/qlu-resource-discovery-tools/resource-count-gcp-v2.py
+++ b/qlu-resource-discovery-tools/resource-count-gcp-v2.py
@@ -1,0 +1,1051 @@
+#!/usr/bin/env python3
+
+# pylint: disable=invalid-name
+
+""" Qualys : Resource Count : GCP """
+
+
+import argparse
+import concurrent.futures
+import csv
+import inspect
+import os
+import signal
+import sys
+
+# As a single script download, we do not publish a requirements.txt. Autodocument.
+
+try:
+    import googleapiclient.discovery
+    import google.auth
+except ImportError:
+    print("\nERROR: Missing required GCP SDK packages. Run the following command to install/upgrade:\n")
+    print("pip3 install --upgrade google-api-python-client")
+    sys.exit(1)
+
+
+version='2.8.4'
+
+
+####
+# Command Line Arguments
+####
+
+
+DEFAULT_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+
+parser = argparse.ArgumentParser(description = 'Count GCP Resources')
+parser.add_argument(
+    '--all',
+    action = 'store_true',
+    dest = 'all',
+    help = 'Count resources in all GCP Projects (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--id',
+    dest = 'id',
+    help = 'Count resources in the specified GCP Project',
+    default = None
+)
+parser.add_argument(
+    '--projects',
+    action = 'store_true',
+    dest = 'input_projects',
+    help = 'Count resources in the list of GCP projects (one ID per line) in a file named projects.txt (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--exclude',
+    action = 'store_true',
+    dest = 'input_excluded_folders',
+    help = 'Exclude folders in the list of GCP Folders (one ID per line) in a file named excluded-folders.txt (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--data',
+    action = 'store_true',
+    dest = 'data_mode',
+    help = 'Count Qualys Cloud Data Security (Buckets, Databases, etc) resources (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--images',
+    action = 'store_true',
+    dest = 'images_mode',
+    help = 'Count Qualys Cloud Registry Container Images (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--ai',
+    action = 'store_true',
+    dest = 'ai_mode',
+    help = 'Count AI/LLM resources (Vertex AI Endpoints, Vertex AI Agents) (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--max-image-tags',
+    action = 'store',
+    dest = 'max_image_tags',
+    help = 'Number of image tags to count per registry image (default: 5, range 1 to 1000)',
+    type = int,
+    default = 5
+)
+parser.add_argument(
+    '--max-workers',
+    dest = 'max_workers',
+    help = f'Maximum parallel processing requests (default: {DEFAULT_MAX_WORKERS}, range 1 to 255)',
+    type = int,
+    default = DEFAULT_MAX_WORKERS
+)
+parser.add_argument(
+    '--debug',
+    action = 'store_true',
+    dest = 'debug_mode',
+    help = 'Disable parallel processing and exit upon first error (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--verbose',
+    action = 'store_true',
+    dest = 'verbose_mode',
+    help = 'Output verbose debugging information (default: disabled)',
+    default = False
+)
+args = parser.parse_args()
+
+if args.max_image_tags < 1 or args.max_image_tags > 1000:
+    print(f"ERROR: --max-image-tags {args.max_image_tags} out of range: [1 .. 1000]")
+    sys.exit(1)
+if args.max_workers < 1 or args.max_workers > 255:
+    print(f"ERROR: --max-workers {args.max_workers} out of range: [1 .. 255]")
+    sys.exit(1)
+
+####
+# Configuration and Globals
+####
+
+
+excluded_folders_file = 'excluded-folders.txt'
+input_file            = 'projects.txt'
+output_file           = 'gcp-resources.csv'
+output_file_log       = 'gcp-resources-log.csv'
+error_log_file        = 'gcp-errors-log.txt'
+padding = 6
+
+# Map command-line arguments to counts to execute and display.
+enabled = {
+    'Virtual Machines':             True,
+    'Container Hosts':              True,
+    'Serverless Functions':         True,
+    'Serverless Containers':        True,
+
+    'Data Buckets':                 True,
+    'PaaS Databases':               True,
+    'Data Warehouses':              True,
+
+    'Non-OS Disks':                 True,
+
+    'Registry Container Images':    args.images_mode,
+
+    'Vertex AI Endpoints':          args.ai_mode,
+    'Vertex AI Agents':             args.ai_mode,
+    'Vertex AI Models':             args.ai_mode,
+
+}
+
+totals = {
+    'Virtual Machines':             0,
+    'Container Hosts':              0,
+    'Serverless Functions':         0,
+    'Serverless Containers':        0,
+
+    'Data Buckets':                 0,
+    'PaaS Databases':               0,
+    'Data Warehouses':              0,
+
+    'Non-OS Disks':                 0,
+    'Registry Container Images':    0,
+
+    'Vertex AI Endpoints':          0,
+    'Vertex AI Agents':             0,
+    'Vertex AI Models':             0,
+
+}
+
+totals_log = []
+errors_log = []
+
+try:
+    google_auth_credential, _ = google.auth.default()
+except Exception:  # pylint: disable=broad-exception-caught
+    google_auth_credential = None
+
+google_api_config = {
+    'credentials': google_auth_credential,
+    'num_retries': 3,
+    'static_discovery': True
+}
+
+
+####
+# Common Library Code
+####
+
+
+def signal_handler(_signal_received, _frame):
+    """ Control-C """
+    print("\nExiting")
+    sys.exit(0)
+
+
+def progress_print(resource_count, resource_type, project='', region='', details=''):
+    """ Resource output """
+    rc = str(resource_count).rjust(padding)
+    # Split and join to remove multiple spaces when variables are empty.
+    print(' '.join(f"- {rc} {resource_type} in {project} {region} {details}".split()))
+    totals_log.append([resource_type, resource_count, project, region])
+
+
+def verbose_print(details):
+    """ Verbose output """
+    if args.verbose_mode:
+        print(f"\nDEBUG: {details}")
+
+
+def error_print(details, project = ''):
+    """ Error output """
+    project  = f"Project: {project} " if project else ""
+    try:
+        function = f"{inspect.stack()[1].function}()"
+    except Exception:  # pylint: disable=broad-exception-caught
+        function = ''
+    try:
+        details = str(details).replace("\n", " ").replace("\r", " ")
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    print(f"\nERROR: {project}{function} {details}\n")
+    errors_log.append(f"ERROR: {project}{function} {details}")
+
+
+####
+# Customized Library Code
+####
+
+
+def tag_in_tags(tag_key, tag_value, tags):
+    """ Check for tag key and value """
+    if not tags:
+        return False
+    return tags.get(tag_key) == tag_value
+
+
+def label_in_labels(label, labels):
+    """ Check for label in list """
+    if not labels:
+        return False
+    return label in labels
+
+
+def get_excluded_folders_from_file():
+    """ Get the list of Excluded GCP Folders """
+    excluded_folders = []
+    if os.path.isfile(excluded_folders_file):
+        with open(excluded_folders_file, encoding='utf-8') as f:
+            excluded_folders = f.read().splitlines()
+    else:
+        error_print(excluded_folders_file + " does not exist.")
+        error_print(f"Create a file named {excluded_folders_file} and add each GCP Folder ID to exclude, one per line.")
+        error_print("Exiting...")
+        sys.exit()
+    excluded_folders.sort()
+    verbose_print(f"excluded_folders: {excluded_folders}")
+    return excluded_folders
+
+
+def get_gcp_enabled_services(project_id):
+    """ Get the list of enabled services for the specified Project """
+    gcp_enabled_services = []
+    try:
+        client = googleapiclient.discovery.build('serviceusage', 'v1', **google_api_config)
+        request = client.services().list(parent='projects/' + project_id, filter='state:ENABLED')
+        while request is not None:
+            response = request.execute()
+            if 'services' in response:
+                for item in response['services']:
+                    gcp_enabled_services.append(item['config']['name'])
+            if 'nextPageToken' in response:
+                request = client.services().list_next(previous_request=request, previous_response=response)
+            else:
+                request = None
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+    client.close()
+    gcp_enabled_services.sort()
+    verbose_print(f"gcp_enabled_services: {gcp_enabled_services}")
+    return gcp_enabled_services
+
+
+def get_gcp_regions(project_id):
+    """ Get GCP Regions for the specified Project """
+    gcp_regions = []
+    try:
+        client = googleapiclient.discovery.build('compute', 'v1', **google_api_config)
+        request = client.regions().list(project=project_id)
+        while request is not None:
+            response = request.execute()
+            if 'items' in response:
+                for region in response['items']:
+                    gcp_regions.append(region['name'])
+            if 'nextPageToken' in response:
+                request = client.regions().list_next(previous_request=request, previous_response=response)
+            else:
+                request = None
+        client.close()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+    #if not gcp_regions:
+    #    error_print(f"No enabled regions found for Project {project_id}")
+    gcp_regions.sort()
+    verbose_print(f"gcp_regions: {gcp_regions}")
+    return gcp_regions
+
+
+# Subscriptions (aka GCP Projects)
+
+
+def get_gcp_projects(excluded_folders):
+    """ Get Active GCP Projects (ID, NAME) """
+    gcp_projects = []
+    try:
+        client = googleapiclient.discovery.build('cloudresourcemanager', 'v1', **google_api_config)
+        request = client.projects().list()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting GCP Projects.")
+        return gcp_projects
+    while request is not None:
+        response = request.execute()
+        if 'projects' in response:
+            for project in response['projects']:
+                if project['lifecycleState'] != 'ACTIVE':
+                    verbose_print(f"- Skipping Inactive Project {project['projectId']}")
+                    continue
+                if 'parent' in project:
+                    parent_folder = project['parent']['id']
+                    if parent_folder in excluded_folders:
+                        verbose_print(f"- Skipping Project {project['projectId']} in Excluded Folder {parent_folder}")
+                        continue
+                gcp_projects.append([project['projectId'], project.get('name', 'UNNAMED')])
+        if 'nextPageToken' in response:
+            request = client.projects().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+    gcp_projects = sorted(gcp_projects, key=lambda p: p[0])
+    verbose_print(f"gcp_projects: {gcp_projects}")
+    return gcp_projects
+
+
+# Subscriptions (aka GCP Projects) from local projects.txt file
+
+
+def get_gcp_projects_from_file():
+    """ Get the list of GCP Projects (ID) from a file named projects.txt """
+    projects_ids = []
+    gcp_projects = []
+    if os.path.isfile(input_file):
+        with open(input_file, encoding='utf-8') as f:
+            for line in f:
+                if len(line.strip()) > 0:
+                    projects_ids.append(line.strip())
+    else:
+        error_print(input_file + " does not exist.")
+        error_print(f"Create a file named {input_file} and add each GCP Project ID to scan, one per line.")
+        error_print("Exiting...")
+        sys.exit()
+
+    # get project names
+    for project_id in projects_ids:
+        try:
+            client = googleapiclient.discovery.build('cloudresourcemanager', 'v1', **google_api_config)
+            request = client.projects().get(projectId=project_id)
+            response = request.execute()
+            gcp_projects.append([project_id, response.get('name', 'UNNAMED')])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, project_id)
+        client.close()
+    gcp_projects = sorted(gcp_projects, key=lambda p: p[0])
+    verbose_print(f"gcp_projects: {gcp_projects}")
+    return gcp_projects
+
+
+# Virtual Machines: Compute Instances and Container Hosts: GKE
+
+# pylint: disable=too-many-locals, too-many-nested-blocks, too-many-statements
+def get_gce_instances_and_gke_instances(project_id, project_name):
+    """ Get GCP Compute and GKE Kubernetes Instances for the specified Project """
+    instances_count = 0
+    gke_instances_count = 0
+    non_os_disks_count = 0
+    linux_instances_count = 0
+    try:
+        client = googleapiclient.discovery.build('compute', 'v1', **google_api_config)
+        request = client.instances().aggregatedList(project=project_id, maxResults=500)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'items' in response:
+            for item in response['items']:
+                # Loop over all GCP Zones in the response.
+                zone_details = response['items'][item]
+                if 'instances' in zone_details:
+                    for instance in zone_details['instances']:
+                        verbose_print(f"virtual_machine: {instance}")
+                        if tag_in_tags('Vendor', 'Databricks', instance.get('tags', {})):
+                            verbose_print(f"Skipping Databricks virtual_machine by tag: {instance['tags']}")
+                            continue
+                        if label_in_labels('databricks', instance.get('labels', [])):
+                            verbose_print(f"Skipping Databricks virtual_machine by labels: {instance['labels']}")
+                            continue
+                        instances_count += 1
+                        is_compute_instance = True
+                        if 'labels' in instance:
+                            for label in instance['labels']:
+                                if label == 'goog-gke-node':
+                                    gke_instances_count += 1
+                                    is_compute_instance = False
+                                    break
+                        # Linux Agent and Non-OS Disks are not applicable to GKE Instances.
+                        if is_compute_instance and 'disks' in instance:
+                            for disk in instance['disks']:
+                                verbose_print(f"disk: {disk}")
+                                if disk['boot']:
+                                    disk_image_details = get_disk_image_details(client, project_id, disk)
+                                    if 'description' not in disk_image_details:
+                                        disk_image_details['description'] = 'UNKNOWN'
+                                    if 'family' not in disk_image_details:
+                                        disk_image_details['family'] = 'UNKNOWN'
+                                    if 'win' not in disk_image_details['description'].lower() and 'win' not in disk_image_details['family'].lower():
+                                        linux_instances_count += 1
+                                else:
+                                    non_os_disks_count += 1
+
+        if 'nextPageToken' in response:
+            request = client.instances().aggregatedList_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=instances_count, resource_type='Virtual Machines [Compute]', project=project_name, details=f"with {non_os_disks_count} Non-OS Disks")
+        totals['Virtual Machines'] += instances_count
+        totals['Non-OS Disks'] += non_os_disks_count
+
+    if gke_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=gke_instances_count, resource_type='Container Hosts [GKE]', project=project_name)
+        totals['Container Hosts'] += gke_instances_count
+
+
+def get_disk_image_details(client, project_id, disk):
+    """ Get Compute Disk Image Details """
+    image_detail = {}
+    disk_zone = disk['source'].split('/')[-3]
+    disk_name = disk['source'].split('/')[-1]
+    try:
+        disk_detail = client.disks().get(project=project_id, zone=disk_zone, disk=disk_name).execute()
+        verbose_print(f"disk detail: {disk_detail}")
+        image_name = disk_detail['sourceImage'].split('/')[-1]
+        image_project = disk_detail['sourceImage'].split('/')[-4]
+        image_detail = client.images().get(project=image_project, image=image_name).execute()
+        verbose_print(f"disk image: {image_detail}")
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+    return image_detail
+
+
+# Serverless Functions: Cloud Functions
+
+
+def get_gcp_cloud_functions(project_id, project_name):
+    """ Get GCP Cloud Functions for the specified Project """
+    serverless_functions_count = 0
+    try:
+        client = googleapiclient.discovery.build('cloudfunctions', 'v2', **google_api_config)
+        request = client.projects().locations().functions().list(parent='projects/' + project_id + '/locations/-')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'functions' in response:
+            serverless_functions_count += len(response['functions'])
+        if 'nextPageToken' in response:
+            request = client.projects().locations().functions().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if serverless_functions_count > 0 or args.verbose_mode:
+        progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [Cloud Functions]', project=project_name)
+        totals['Serverless Functions'] += serverless_functions_count
+
+
+# Serverless Containers: Cloud Run Revisions
+
+
+def get_gcp_cloudrun_revisions(project_id, project_name):
+    """ Get GCP Cloud Run Revisions for the specified Project """
+    serverless_containers_count = 0
+    try:
+        client = googleapiclient.discovery.build('run', 'v1', **google_api_config)
+        request = client.namespaces().revisions().list(parent='namespaces/' + project_id, labelSelector='serving.knative.dev/revisionStatus=active')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'items' in response:
+            for item in response['items']:
+                for container in item['status']['conditions']:
+                    if container['type'] == 'ContainerHealthy' and container['status'] == 'True':
+                        serverless_containers_count += 1
+        if 'nextPageToken' in response:
+            request = client.namespaces().revisions().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if serverless_containers_count > 0 or args.verbose_mode:
+        progress_print(resource_count=serverless_containers_count, resource_type='Serverless Containers [Cloud Run Revisions]', project=project_name)
+        totals['Serverless Containers'] += serverless_containers_count
+
+
+# Serverless Containers: GKE Autopilot
+
+def get_gcp_gke_clusters(project_id, project_name):
+    """ Get GCP Clusters for the specified Project """
+    gke_nodes_count = 0
+    gke_containers_count = 0
+    try:
+        client = googleapiclient.discovery.build('container', 'v1', **google_api_config)
+        request = client.projects().zones().clusters().list(projectId=project_id, zone='-')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'clusters' in response:
+            for cluster in response['clusters']:
+                verbose_print(f"gke_cluster: {cluster}")
+                if 'autopilot' in cluster and 'enabled' in cluster['autopilot']:
+                    if cluster['autopilot']['enabled'] is True:
+                        node_pools = cluster.get('nodePools', [])
+                        for node_pool in node_pools:
+                            node_count    = node_pool.get('currentNodeCount', node_pool.get('initialNodeCount', 0))
+                            pods_per_node = node_pool.get('config', {}).get('maxPodsPerNode', 0)
+                            gke_nodes_count      += node_count
+                            gke_containers_count += node_count * pods_per_node
+        if 'nextPageToken' in response:
+            request = client.projects().zones().clusters().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if gke_nodes_count > 0 or args.verbose_mode:
+        progress_print(resource_count=gke_nodes_count, resource_type='Kubernetes Agents [GKE Autopilot]', project=project_name)
+
+    if gke_containers_count > 0 or args.verbose_mode:
+        progress_print(resource_count=gke_containers_count, resource_type='Serverless Containers [GKE Autopilot]', project=project_name)
+        totals['Serverless Containers'] += gke_containers_count
+
+
+# Registry Container Images: GAR
+
+# Limits: 1000 Container Images per Container Registry
+
+
+def get_gcp_gcr_images(project_id, project_name, region):
+    """ Get GAR Container Images for the specified Project and Region """
+    repositories = []
+    container_registry_images = 0
+    try:
+        client = googleapiclient.discovery.build('artifactregistry', 'v1', **google_api_config)
+        request = client.projects().locations().repositories().list(parent='projects/' + project_id + '/locations/' + region)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'repositories' in response:
+            for item in response['repositories']:
+                verbose_print(f"repository: {item}")
+                if item['format'] == 'DOCKER':
+                    repository = item['name'].split('/')[-1]
+                    repositories.append(repository)
+        if 'nextPageToken' in response:
+            request = client.projects().locations().repositories().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    for repository in repositories:
+        container_registry_images_in_repository = 0
+        try:
+            request = client.projects().locations().repositories().dockerImages().list(parent='projects/' + project_id + '/locations/' + region + '/repositories/' + repository)
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex, project_id)
+            continue
+        while request is not None:
+            response = request.execute()
+            if 'dockerImages' in response:
+                for image in response['dockerImages']:
+                    verbose_print(f"image: {image}")
+                    if 'tags' in image:
+                        container_registry_images_in_repository += min(args.max_image_tags, len(image['tags']))
+                    else:
+                        container_registry_images_in_repository += 1
+            if 'nextPageToken' in response:
+                try:
+                    request = client.projects().locations().repositories().dockerImages().list_next(previous_request=request, previous_response=response)
+                except Exception as ex:  # pylint: disable=broad-exception-caught
+                    error_print(ex, project_id)
+                    continue
+            else:
+                request = None
+        container_registry_images_in_repository = min(container_registry_images_in_repository, 10000)
+        container_registry_images += container_registry_images_in_repository
+
+    client.close()
+
+    if container_registry_images > 0 or args.verbose_mode:
+        progress_print(resource_count=container_registry_images, resource_type='Registry Container Images [GAR]', project=project_name, region=region)
+        totals['Registry Container Images'] += container_registry_images
+
+
+# Data Buckets: Buckets
+
+# Limits: 10000 Storage Buckets per GCP Project
+
+
+def get_gcp_buckets(project_id, project_name):
+    """ Get GCP Buckets for the specified Project """
+    buckets_count = 0
+    try:
+        client = googleapiclient.discovery.build('storage', 'v1', **google_api_config)
+        request = client.buckets().list(project=project_id)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'items' in response:
+            buckets_count += len(response['items'])
+        if 'nextPageToken' in response:
+            request = client.buckets().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+    buckets_count = min(buckets_count, 10000)
+
+    if buckets_count> 0 or args.verbose_mode:
+        progress_print(resource_count=buckets_count, resource_type='Data Buckets', project=project_name)
+        totals['Data Buckets'] += buckets_count
+
+
+# Data: PaaS Databases: Cloud SQL
+
+
+def get_gcp_cloudsql_instances(project_id, project_name):
+    """ Get GCP Cloud SQL Instances for the specified Project"""
+    database_instances_count = 0
+    try:
+        client = googleapiclient.discovery.build('sqladmin', 'v1', **google_api_config)
+        request = client.instances().list(project=project_id)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'items' in response:
+            database_instances_count += len(response['items'])
+        if 'nextPageToken' in response:
+            request = client.instances().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if database_instances_count > 0 or args.verbose_mode:
+        progress_print(resource_count=database_instances_count, resource_type='PaaS Databases [Cloud SQL]', project=project_name)
+        totals['PaaS Databases'] += database_instances_count
+
+
+# Data: PaaS Databases: Spanner
+
+
+def get_gcp_spanner_instances(project_id, project_name):
+    """ Get GCP Spanner Instances for the specified Project"""
+    instances_databases_count = 0
+    try:
+        client = googleapiclient.discovery.build('spanner', 'v1', **google_api_config)
+        request = client.projects().instances().list(parent=f'projects/{project_id}')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'instances' in response:
+            for instance in response['instances']:
+                instances_databases_count += get_gcp_spanner_databases(client, instance['name'])
+        if 'nextPageToken' in response:
+            request = client.projects().instances().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if instances_databases_count > 0 or args.verbose_mode:
+        progress_print(resource_count=instances_databases_count, resource_type='PaaS Databases [Spanner]', project=project_name)
+        totals['PaaS Databases'] += instances_databases_count
+
+
+##
+
+
+def get_gcp_spanner_databases(client, instance_id):
+    """ Get GCP Spanner Databases for the specified Instance"""
+    database_count = 0
+    try:
+        request = client.projects().instances().databases().list(parent=instance_id)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, instance_id)
+        return database_count
+    while request is not None:
+        response = request.execute()
+        if 'databases' in response:
+            database_count += len(response['databases'])
+        if 'nextPageToken' in response:
+            request = client.projects().instances().databases().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    return database_count
+
+
+# Data: Data Warehouses: BigQuery
+
+
+def get_gcp_bigquery_datasets(project_id, project_name):
+    """ Get GCP BigQuery Tables for the specified Project"""
+    data_warehouses_count = 0
+    try:
+        client = googleapiclient.discovery.build('bigquery', 'v2', **google_api_config)
+        request = client.datasets().list(projectId=project_id)
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'datasets' in response:
+            data_warehouses_count += len(response['datasets'])
+        if 'nextPageToken' in response:
+            request = client.datasets().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if data_warehouses_count > 0 or args.verbose_mode:
+        progress_print(resource_count=data_warehouses_count, resource_type='Data Warehouses [BigQuery]', project=project_name)
+        totals['Data Warehouses'] += data_warehouses_count
+
+
+# AI/LLM: Vertex AI Endpoints
+
+
+def get_gcp_vertex_ai_endpoints(project_id, project_name):
+    """ Get GCP Vertex AI Endpoints for the specified Project """
+    vertex_ai_endpoints_count = 0
+    try:
+        client = googleapiclient.discovery.build('aiplatform', 'v1', **google_api_config)
+        request = client.projects().locations().endpoints().list(parent=f'projects/{project_id}/locations/-')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'endpoints' in response:
+            vertex_ai_endpoints_count += len(response['endpoints'])
+        if 'nextPageToken' in response:
+            request = client.projects().locations().endpoints().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if vertex_ai_endpoints_count > 0 or args.verbose_mode:
+        progress_print(resource_count=vertex_ai_endpoints_count, resource_type='Vertex AI Endpoints', project=project_name)
+        totals['Vertex AI Endpoints'] += vertex_ai_endpoints_count
+
+
+# AI/LLM: Vertex AI Agents (Dialogflow CX)
+
+
+def get_gcp_vertex_ai_agents(project_id, project_name):
+    """ Get GCP Vertex AI Agents (Dialogflow CX) for the specified Project """
+    vertex_ai_agents_count = 0
+    try:
+        client = googleapiclient.discovery.build('dialogflow', 'v3', **google_api_config)
+        request = client.projects().locations().agents().list(parent=f'projects/{project_id}/locations/-')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'agents' in response:
+            vertex_ai_agents_count += len(response['agents'])
+        if 'nextPageToken' in response:
+            request = client.projects().locations().agents().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if vertex_ai_agents_count > 0 or args.verbose_mode:
+        progress_print(resource_count=vertex_ai_agents_count, resource_type='Vertex AI Agents', project=project_name)
+        totals['Vertex AI Agents'] += vertex_ai_agents_count
+
+
+# AI/LLM: Vertex AI Models
+
+
+def get_gcp_vertex_ai_models(project_id, project_name):
+    """ Get GCP Vertex AI Models for the specified Project """
+    vertex_ai_models_count = 0
+    try:
+        client = googleapiclient.discovery.build('aiplatform', 'v1', **google_api_config)
+        request = client.projects().locations().models().list(parent=f'projects/{project_id}/locations/-')
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex, project_id)
+        return
+    while request is not None:
+        response = request.execute()
+        if 'models' in response:
+            vertex_ai_models_count += len(response['models'])
+        if 'nextPageToken' in response:
+            request = client.projects().locations().models().list_next(previous_request=request, previous_response=response)
+        else:
+            request = None
+    client.close()
+
+    if vertex_ai_models_count > 0 or args.verbose_mode:
+        progress_print(resource_count=vertex_ai_models_count, resource_type='Vertex AI Models', project=project_name)
+        totals['Vertex AI Models'] += vertex_ai_models_count
+
+
+####
+# Main
+####
+
+# pylint: disable=too-many-branches
+def get_gcp_resources(project_id, project_name):
+    """ Get countable resources for the specified Project """
+    exceptions = 0
+    regions_list = []
+    service_list = get_gcp_enabled_services(project_id)
+    if 'compute.googleapis.com' in service_list:
+        regions_list = get_gcp_regions(project_id=project_id)
+    if not service_list:
+        print(f"Skipping GCP Project: {project_id} no services enabled.")
+        return
+    # If debug mode is disabled (default), run all functions concurrently with multithreading.
+    # If debug mode is enabled, run all functions sequentially without multithreading.
+    if args.debug_mode:
+        if enabled['Virtual Machines'] or enabled['Container Hosts']:
+            if 'compute.googleapis.com' in service_list:
+                get_gce_instances_and_gke_instances(project_id=project_id, project_name=project_name)
+        if enabled['Container Hosts'] or enabled['Serverless Containers']:
+            if 'container.googleapis.com' in service_list:
+                get_gcp_gke_clusters(project_id=project_id, project_name=project_name)
+        if enabled['Serverless Functions']:
+            if 'cloudfunctions.googleapis.com' in service_list:
+                get_gcp_cloud_functions(project_id=project_id, project_name=project_name)
+        if enabled['Serverless Containers']:
+            if 'run.googleapis.com' in service_list:
+                get_gcp_cloudrun_revisions(project_id=project_id, project_name=project_name)
+        if enabled['Data Buckets']:
+            if 'storage.googleapis.com' in service_list:
+                get_gcp_buckets(project_id=project_id, project_name=project_name)
+        if enabled['PaaS Databases']:
+            if 'sqladmin.googleapis.com' in service_list:
+                get_gcp_cloudsql_instances(project_id=project_id, project_name=project_name)
+            if 'spanner.googleapis.com' in service_list:
+                get_gcp_spanner_instances(project_id=project_id, project_name=project_name)
+        if enabled['Data Warehouses']:
+            if 'bigquery.googleapis.com' in service_list:
+                get_gcp_bigquery_datasets(project_id=project_id, project_name=project_name)
+        if enabled['Registry Container Images']:
+            if 'artifactregistry.googleapis.com' in service_list:
+                for region in regions_list:
+                    get_gcp_gcr_images(project_id=project_id, project_name=project_name, region=region)
+        if enabled['Vertex AI Endpoints']:
+            if 'aiplatform.googleapis.com' in service_list:
+                get_gcp_vertex_ai_endpoints(project_id=project_id, project_name=project_name)
+        if enabled['Vertex AI Agents']:
+            if 'dialogflow.googleapis.com' in service_list:
+                get_gcp_vertex_ai_agents(project_id=project_id, project_name=project_name)
+        if enabled['Vertex AI Models']:
+            if 'aiplatform.googleapis.com' in service_list:
+                get_gcp_vertex_ai_models(project_id=project_id, project_name=project_name)
+    else:
+        futures = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            if enabled['Virtual Machines'] or enabled['Container Hosts']:
+                if 'compute.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gce_instances_and_gke_instances, project_id=project_id, project_name=project_name))
+            if enabled['Container Hosts'] or enabled['Serverless Containers']:
+                if 'container.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_gke_clusters, project_id=project_id, project_name=project_name))
+            if enabled['Serverless Functions']:
+                if 'cloudfunctions.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_cloud_functions, project_id=project_id, project_name=project_name))
+            if enabled['Serverless Containers']:
+                if 'run.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_cloudrun_revisions, project_id=project_id, project_name=project_name))
+            if enabled['Data Buckets']:
+                if 'storage-api.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_buckets, project_id=project_id, project_name=project_name))
+            if enabled['PaaS Databases']:
+                if 'sqladmin.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_cloudsql_instances, project_id=project_id, project_name=project_name))
+                if 'spanner.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_spanner_instances, project_id=project_id, project_name=project_name))
+            if enabled['Data Warehouses']:
+                if 'bigquery.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_bigquery_datasets, project_id=project_id, project_name=project_name))
+            if enabled['Registry Container Images']:
+                if 'artifactregistry.googleapis.com' in service_list:
+                    for region in regions_list:
+                        futures.append(executor.submit(get_gcp_gcr_images, project_id=project_id, project_name=project_name, region=region))
+            if enabled['Vertex AI Endpoints']:
+                if 'aiplatform.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_vertex_ai_endpoints, project_id=project_id, project_name=project_name))
+            if enabled['Vertex AI Agents']:
+                if 'dialogflow.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_vertex_ai_agents, project_id=project_id, project_name=project_name))
+            if enabled['Vertex AI Models']:
+                if 'aiplatform.googleapis.com' in service_list:
+                    futures.append(executor.submit(get_gcp_vertex_ai_models, project_id=project_id, project_name=project_name))
+        for future in concurrent.futures.as_completed(futures):
+            if future.exception():
+                exceptions += 1
+
+
+def output_results(projects):
+    """ Output results """
+    # Summary File
+    with open(output_file, 'w', encoding='utf-8', newline='') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count'])
+        for resource_type, resource_count in totals.items():
+            csv_writer.writerow([resource_type, resource_count])
+    # Log File
+    with open(output_file_log, 'w', encoding='utf-8') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count', 'Project', 'Region'])
+        for item in totals_log:
+            csv_writer.writerow(item)
+
+    # Error File
+    if errors_log:
+        with open(error_log_file, 'w', encoding='utf-8') as err_file:
+            for error in errors_log:
+                err_file.write(error + "\n")
+
+    # Summary
+    print(f"\nResults across {len(projects)} GCP Projects (script version: {version})\n")
+
+    if enabled['Virtual Machines']:
+        print(f"{str(totals['Virtual Machines']).rjust(padding)} Virtual Machines [Compute Instances]")
+    if enabled['Container Hosts']:
+        print(f"{str(totals['Container Hosts']).rjust(padding)} Container Hosts [GKE]")
+    if enabled['Serverless Functions']:
+        print(f"{str(totals['Serverless Functions']).rjust(padding)} Serverless Functions [Cloud Functions]")
+    if enabled['Serverless Containers']:
+        print(f"{str(totals['Serverless Containers']).rjust(padding)} Serverless Containers [Cloud Run Revisions, GKE Autopilot]")
+
+    if enabled['Data Buckets']:
+        print()
+        print(f"{str(totals['Data Buckets']).rjust(padding)} Data Buckets (Public and Private) [Buckets]")
+    if enabled['PaaS Databases']:
+        print(f"{str(totals['PaaS Databases']).rjust(padding)} PaaS Databases [Cloud SQL, Spanner]")
+    if enabled['Data Warehouses']:
+        print(f"{str(totals['Data Warehouses']).rjust(padding)} Data Warehouses [BigQuery]")
+
+    if enabled['Non-OS Disks']:
+        print()
+        print(f"{str(totals['Non-OS Disks']).rjust(padding)} Non-OS Disks [Compute Instances]")
+    if enabled['Registry Container Images']:
+        print()
+        print(f"{str(totals['Registry Container Images']).rjust(padding)} Registry Container Images [GAR]")
+
+    if enabled['Vertex AI Endpoints'] or enabled['Vertex AI Agents'] or enabled['Vertex AI Models']:
+        print()
+    if enabled['Vertex AI Endpoints']:
+        print(f"{str(totals['Vertex AI Endpoints']).rjust(padding)} Vertex AI Endpoints")
+    if enabled['Vertex AI Agents']:
+        print(f"{str(totals['Vertex AI Agents']).rjust(padding)} Vertex AI Agents")
+    if enabled['Vertex AI Models']:
+        print(f"{str(totals['Vertex AI Models']).rjust(padding)} Vertex AI Models")
+
+    if not args.data_mode:
+        print()
+        print("To count Data Security (Buckets, Databases, etc) resources, rerun with '--data'")
+    if not args.images_mode:
+        print()
+        print("To count Registry Container Images, rerun with '--images'")
+    if not args.ai_mode:
+        print()
+        print("To count AI/LLM resources, rerun with '--ai'")
+
+    print(f"\nDetails written to {output_file} and {output_file_log}")
+
+    if errors_log:
+        print("\nExceptions occurred.")
+        print(f"Review {error_log_file} or rerun with '--debug' to disable parallel processing and exit upon first error.")
+
+
+def main():
+    """ Calculon Compute! """
+    projects = []
+
+    excluded_folders = []
+    if args.input_excluded_folders:
+        print(f"Getting GCP Excluded Folders from {excluded_folders_file}\n")
+        excluded_folders = get_excluded_folders_from_file()
+
+    if args.all:
+        print("Getting GCP Projects")
+        projects = get_gcp_projects(excluded_folders)
+        print(f"\n- Found {len(projects)} GCP Projects")
+        for project in projects:
+            print(f"-- {project[1]}")
+        print('')
+    elif args.input_projects:
+        print(f"Getting GCP Projects from file: {input_file}")
+        projects = get_gcp_projects_from_file()
+    else:
+        if args.id:
+            print(f"Getting GCP Project {args.id}")
+            projects = [[args.id, args.id]]
+        else:
+            project_id = input("Enter the GCP Project ID to scan: ")
+            print('')
+            projects = [[project_id, project_id]]
+
+    print("\nGetting Countable Resources for each GCP Project ...")
+    for project_id, project_name in projects:
+        print(f"\nScanning {project_id} ...")
+        get_gcp_resources(project_id, project_name)
+
+    output_results(projects)
+
+
+if __name__ == '__main__':
+    signal.signal(signal.SIGINT,signal_handler)
+    main()

--- a/qlu-resource-discovery-tools/resource-count-oci.py
+++ b/qlu-resource-discovery-tools/resource-count-oci.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+
+# pylint: disable=invalid-name
+
+""" Qualys : Resource Count : OCI """
+
+# pip3 install oci
+
+import argparse
+import concurrent.futures
+import csv
+import inspect
+import json
+import os
+import signal
+import sys
+
+# As a single script download, we do not publish a requirements.txt. Autodocument.
+
+try:
+    import oci
+except ImportError:
+    print("\nERROR: Missing required OCI SDK packages. Run the following command to install/upgrade:\n")
+    print("pip3 install --upgrade oci")
+    sys.exit(1)
+
+
+version='2.8.0'
+
+
+####
+# Command Line Arguments
+####
+
+
+DEFAULT_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+
+parser = argparse.ArgumentParser(description = 'Count OCI Resources')
+parser.add_argument(
+    '--data',
+    action = 'store_true',
+    dest = 'data_mode',
+    help = 'Count Data Security (Buckets, etc) resources (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--max-workers',
+    dest = 'max_workers',
+    help = f'Maximum parallel processing requests (default: {DEFAULT_MAX_WORKERS}, range 1 to 255)',
+    type = int,
+    default = DEFAULT_MAX_WORKERS
+)
+parser.add_argument(
+    '--debug',
+    action = 'store_true',
+    dest = 'debug_mode',
+    help = 'Disable parallel processing and exit upon first error (default: disabled)',
+    default = False
+)
+parser.add_argument(
+    '--verbose',
+    action = 'store_true',
+    dest = 'verbose_mode',
+    help = 'Output verbose debugging information (default: disabled)',
+    default = False
+)
+args = parser.parse_args()
+
+if args.max_workers < 1 or args.max_workers > 255:
+    print(f"ERROR: --max-workers {args.max_workers} out of range: [1 .. 255]")
+    sys.exit(1)
+
+
+####
+# Configuration and Globals
+####
+
+
+delegation_token_file = '/etc/oci/delegation_token'
+output_file           = 'oci-resources.csv'
+output_file_log       = 'oci-resources-log.csv'
+error_log_file        = 'oci-errors-log.txt'
+padding = 6
+
+# Map command-line arguments to counts to execute and display.
+enabled = {
+    'Virtual Machines':        True,
+    'Container Hosts':         True,
+    'Serverless Functions':    True,
+
+    'Data Buckets':            args.data_mode,
+
+}
+
+totals = {
+    'Virtual Machines':         0,
+    'Container Hosts':          0,
+    'Serverless Functions':     0,
+    'Serverless Containers':    0,
+
+    'Data Buckets':             0,
+
+}
+
+totals_log = []
+errors_log = []
+
+
+####
+# Common Library Code
+####
+
+
+def signal_handler(_signal_received, _frame):
+    """ Control-C """
+    print("\nExiting")
+    sys.exit(0)
+
+
+def progress_print(resource_count, resource_type, region=''):
+    """ Resource output """
+    rc = str(resource_count).rjust(padding)
+    # Split and join to remove multiple spaces when variables are empty.
+    print(' '.join(f"- {rc} {resource_type} in {region}".split()))
+    totals_log.append([resource_type, resource_count, region])
+
+
+def verbose_print(details):
+    """ Verbose output """
+    if args.verbose_mode:
+        print(f"\nDEBUG: {details}")
+
+
+def error_print(details, compartment = ''):
+    """ Error output """
+    compartment  = f"Compartment: {compartment} " if compartment else ""
+    try:
+        function = f"{inspect.stack()[1].function}()"
+    except Exception:  # pylint: disable=broad-exception-caught
+        function = ''
+    try:
+        details = str(details).replace("\n", " ").replace("\r", " ")
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    print(f"\nERROR: {compartment}{function} {details}\n")
+    errors_log.append(f"ERROR: {compartment}{function} {details}")
+
+####
+# Customized Library Code
+####
+
+
+# Subscriptions (aka OCI Compartments)
+
+
+def get_oci_compartments(config, signer):
+    """ Get a list of OCI Compartments """
+    try:
+        compartments = []
+        identity_client = oci.identity.IdentityClient(config=config, signer=signer)
+        get_compartment_response = identity_client.get_compartment(compartment_id=config['tenancy'])
+        root_compartment = json.loads(str(get_compartment_response.data))
+        root_compartment['compartment_id'] = root_compartment['id']
+        compartments.append(root_compartment)
+        verbose_print(f"root_compartment: {root_compartment}")
+        response = identity_client.list_compartments(compartment_id=config['tenancy'], compartment_id_in_subtree=True, limit=1000)
+        verbose_print(f"compartments: {response.data}")
+        compartments.extend(json.loads(str(response.data)))
+        while response.has_next_page:
+            response = identity_client.list_compartments(compartment_id=config['tenancy'], compartment_id_in_subtree=True, limit=1000, page=response.next_page)
+            verbose_print(f"compartments: {response.data}")
+            compartments.extend(json.loads(str(response.data)))
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting OCI Compartments.")
+        error_print("Exiting...")
+        sys.exit()
+    verbose_print(f"compartments: {compartments}")
+    return compartments
+
+
+def get_oci_regions(config, signer):
+    """ Get a list of OCI Regions """
+    try:
+        identity_client = oci.identity.IdentityClient(config, signer=signer)
+        list_regions_response = identity_client.list_region_subscriptions(tenancy_id=config['tenancy'])
+        regions = json.loads(str(list_regions_response.data))
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error getting OCI Regions.")
+        error_print("Exiting...")
+    verbose_print(f"regions: {regions}")
+    return regions
+
+
+def config_for_region(config, region):
+    """ Create or modify an OCI config with the specified region. """
+    region_config = config
+    if region_config:
+        region_config['region'] = region['region_key']
+    else:
+        region_config = {'region': region['region_key']}
+    return region_config
+
+
+# Virtual Machines: Compute Instances and Container Hosts: OKE
+
+
+def get_oci_instances_and_oke_instances(config, signer, compartment, regions):
+    """ Get OCI Compute Instances and OKE Instances """
+    for region in regions:
+        instances = []
+        instances_count = 0
+        container_instances_count = 0
+        linux_instances_count = 0
+        try:
+            search_client = oci.resource_search.ResourceSearchClient(config=config_for_region(config, region), signer=signer)
+            response = search_client.search_resources(
+                oci.resource_search.models.StructuredSearchDetails(
+                    type="Structured",
+                   query=f"query instance resources return allAdditionalFields where compartmentId = '{compartment['id']}' && lifeCycleState != 'TERMINATED' && lifeCycleState != 'TERMINATING'")
+            )
+            verbose_print(f"instances: {response.data}")
+            instances = json.loads(str(response.data))['items']
+            while response.has_next_page:
+                response = search_client.search_resources(
+                    oci.resource_search.models.StructuredSearchDetails(
+                        type="Structured",
+                        query=f"query instance resources return allAdditionalFields where compartmentId = '{compartment['id']}' && lifeCycleState != 'TERMINATED' && lifeCycleState != 'TERMINATING'"),
+                    page=response.next_page
+                )
+                verbose_print(f"instances: {response.data}")
+                instances.extend(json.loads(str(response.data))['items'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(f"Exception getting Instances in Region: {region}: {ex}", compartment['id'])
+        core_client = oci.core.ComputeClient(config=config_for_region(config, region), signer=signer)
+        for instance in instances:
+            verbose_print(f"virtual_machine: {instance}")
+            instances_count += 1
+            if 'defined_tags' in instance and 'Oracle-Tags' in instance['defined_tags'] and instance['defined_tags']['Oracle-Tags']['CreatedBy'] == 'oke':
+                container_instances_count += 1
+            operating_system = get_oci_image_operating_system(core_client, instance['additional_details']['imageId'])
+            if operating_system and 'win' not in operating_system.lower():
+                linux_instances_count += 1
+
+        if instances_count > 0 or args.verbose_mode:
+            progress_print(resource_count=instances_count, resource_type='Virtual Machines [Compute]', region=region['region_name'])
+            totals['Virtual Machines'] += instances_count
+
+        if container_instances_count > 0 or args.verbose_mode:
+            progress_print(resource_count=container_instances_count, resource_type='Container Hosts [OKE]', region=region['region_name'])
+            totals['Container Hosts'] += container_instances_count
+
+
+def get_oci_image_operating_system(core_client, image_id):
+    """ Get OCI Compute Image """
+    try:
+        image = core_client.get_image(image_id=image_id)
+        verbose_print(f"image: {image.data}")
+        return image.data.operating_system
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(f"Exception getting Operating System for Image: {image_id}: {ex}")
+        return ''
+
+
+# Serverless Functions: FunctionsFunction (FunctionsApplication ?)
+
+
+def get_oci_cloud_functions_function(config, signer, compartment, regions):
+    """ Get OCI Cloud Functions """
+    for region in regions:
+        serverless_functions_count = 0
+        try:
+            search_client = oci.resource_search.ResourceSearchClient(config=config_for_region(config, region), signer=signer)
+            query_text = f"query functionsfunction resources where compartmentId = '{compartment['id']}' && lifeCycleState != 'DELETED' && lifeCycleState != 'DELETING'"
+            response = search_client.search_resources(
+                oci.resource_search.models.StructuredSearchDetails(
+                    type="Structured",
+                    query=query_text)
+            )
+            verbose_print(f"functions: {response.data}")
+            items = json.loads(str(response.data))['items']
+            serverless_functions_count = len(items)
+            while response.has_next_page:
+                response = search_client.search_resources(
+                    oci.resource_search.models.StructuredSearchDetails(
+                        type="Structured",
+                        query=query_text),
+                    page=response.next_page
+                )
+                verbose_print(f"functions: {response.data}")
+                serverless_functions_count += len(json.loads(str(response.data))['items'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(f"Exception getting Serverless Functions in Region: {region}: {ex}", compartment['id'])
+
+        if serverless_functions_count > 0 or args.verbose_mode:
+            progress_print(resource_count=serverless_functions_count, resource_type='Serverless Functions [Functions]', region=region['region_name'])
+            totals['Serverless Functions'] += serverless_functions_count
+
+
+def get_oci_buckets(config, signer, compartment, regions):
+    """ Get OCI Buckets """
+    for region in regions:
+        buckets_count = 0
+        try:
+            search_client = oci.resource_search.ResourceSearchClient(config=config_for_region(config, region), signer=signer)
+            response = search_client.search_resources(
+                oci.resource_search.models.StructuredSearchDetails(
+                    type="Structured",
+                    query=f"query bucket resources where compartmentId = '{compartment['id']}' && lifeCycleState != 'TERMINATED' && lifeCycleState != 'TERMINATING'")
+            )
+            verbose_print(f"buckets: {response.data}")
+            buckets_count = len(json.loads(str(response.data))['items'])
+            while response.has_next_page:
+                response = search_client.search_resources(
+                    oci.resource_search.models.StructuredSearchDetails(
+                        type="Structured",
+                        query=f"query bucket resources where compartmentId = '{compartment['id']}' && lifeCycleState != 'TERMINATED' && lifeCycleState != 'TERMINATING'"),
+                    page=response.next_page
+                )
+                verbose_print(f"buckets: {response.data}")
+                buckets_count += len(json.loads(str(response.data))['items'])
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(f"Exception getting Buckets in Region: {region}: {ex}", compartment['id'])
+
+        if buckets_count > 0 or args.verbose_mode:
+            progress_print(resource_count=buckets_count, resource_type='Buckets', region=region['region_name'])
+            totals['Data Buckets'] += buckets_count
+
+
+####
+# Main
+####
+
+
+def get_oci_resources(config, signer, compartment, regions):
+    """ Get countable resources """
+    exceptions = 0
+    # If debug mode is disabled (default), run all functions concurrently with multithreading.
+    # If debug mode is enabled, run all functions sequentially without multithreading.
+    if args.debug_mode:
+        if enabled['Virtual Machines'] or enabled['Container Hosts']:
+            get_oci_instances_and_oke_instances(config, signer=signer, compartment=compartment, regions=regions)
+            if enabled['Serverless Functions']:
+                get_oci_cloud_functions_function(config, signer=signer, compartment=compartment, regions=regions)
+        if enabled['Data Buckets']:
+            get_oci_buckets(config, signer=signer, compartment=compartment, regions=regions)
+    else:
+        futures = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            if enabled['Virtual Machines'] or enabled['Container Hosts']:
+                futures.append(executor.submit(get_oci_instances_and_oke_instances, config, compartment=compartment, signer=signer, regions=regions))
+                if enabled['Serverless Functions']:
+                    futures.append(executor.submit(get_oci_cloud_functions_function, config, signer=signer, compartment=compartment, regions=regions))
+            if enabled['Data Buckets']:
+                futures.append(executor.submit(get_oci_buckets, config, signer=signer, compartment=compartment, regions=regions))
+        for future in concurrent.futures.as_completed(futures):
+            if future.exception():
+                exceptions += 1
+
+
+def output_results(compartments):
+    """ Output results """
+    # Summary File
+    with open(output_file, 'w', encoding='utf-8', newline='') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count'])
+        for resource_type, resource_count in totals.items():
+            csv_writer.writerow([resource_type, resource_count])
+    # Log File
+    with open(output_file_log, 'w', encoding='utf-8') as csv_file:
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(['Resource Type', 'Resource Count', 'Region'])
+        for item in totals_log:
+            csv_writer.writerow(item)
+
+    # Error File
+    if errors_log:
+        with open(error_log_file, 'w', encoding='utf-8') as err_file:
+            for error in errors_log:
+                err_file.write(error + "\n")
+
+    # Summary
+    print(f"\nResults across {len(compartments)} OCI Compartments (script version: {version})\n")
+
+    if enabled['Virtual Machines']:
+        print(f"{str(totals['Virtual Machines']).rjust(padding)} Virtual Machines [Compute Instances]")
+    if enabled['Container Hosts']:
+        print(f"{str(totals['Container Hosts']).rjust(padding)} Container Hosts [OKE]")
+    if enabled['Serverless Functions']:
+        print(f"{str(totals['Serverless Functions']).rjust(padding)} Serverless Functions [Cloud Functions]")
+
+    if enabled['Data Buckets']:
+        print()
+        print(f"{str(totals['Data Buckets']).rjust(padding)} Data Buckets (Public and Private) [Buckets]")
+
+    if not args.data_mode:
+        print("\nTo count Data Security (Buckets, Databases, etc) resources, rerun with '--data'")
+
+    print(f"\nDetails written to {output_file} and {output_file_log}")
+
+    if errors_log:
+        print("\nExceptions occurred.")
+        print(f"Review {error_log_file} or rerun with '--debug' to disable parallel processing and exit upon first error.")
+
+
+def main():
+    """ Calculon Compute! """
+    try:
+        config = oci.config.from_file(oci.config.DEFAULT_LOCATION, oci.config.DEFAULT_PROFILE)
+        verbose_print(f"configuration: {config} from {oci.config.DEFAULT_LOCATION} using {oci.config.DEFAULT_PROFILE} profile")
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        error_print(ex)
+        error_print("Error reading OCI configuration from default Location and Profile.")
+        error_print("Exiting...")
+        sys.exit(0)
+
+    if os.path.isfile(delegation_token_file):
+        with open(delegation_token_file, 'r', encoding='utf-8') as f:
+            delegation_token = f.read().strip()
+        try:
+            signer = oci.auth.signers.InstancePrincipalsDelegationTokenSigner(
+                delegation_token = delegation_token
+            )
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex)
+            error_print("Error authenticating via Delegation Token File.")
+            error_print("Exiting...")
+            sys.exit(0)
+    else:
+        try:
+            signer = oci.signer.Signer(
+                tenancy                   = config['tenancy'],
+                user                      = config['user'],
+                fingerprint               = config['fingerprint'],
+                private_key_file_location = config.get('key_file'),
+            )
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            error_print(ex)
+            error_print("Error authenticating via Profile.")
+            error_print("Exiting...")
+            sys.exit(0)
+
+    regions = get_oci_regions(config, signer)
+
+    print("Getting OCI Compartments")
+    compartments = get_oci_compartments(config, signer)
+    print(f"\nFound {len(compartments)} Compartments:")
+    for compartment in compartments:
+        print(f"- {compartment['id']} - {compartment['name']}")
+
+    print("\nGetting Countable Resources for each OCI Compartment ...")
+    for compartment in compartments:
+        print(f"\nScanning {compartment['id']} - {compartment['name']}")
+        get_oci_resources(config, signer, compartment, regions)
+
+    output_results(compartments)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT,signal_handler)
+    main()


### PR DESCRIPTION
## What this does

Adds the full suite of Qualys cloud resource count scripts to `qlu-resource-discovery-tools/`.

## Scripts

| Script | Version | Cloud | Description |
|--------|---------|-------|-------------|
| `resource-count-aws-v2.py` | 2.8.1 | AWS | Counts resources across all accounts/org |
| `resource-count-azure-v2.py` | 2.8.4 | Azure | Counts resources across all subscriptions |
| `resource-count-gcp-v2.py` | 2.8.4 | GCP | Counts resources across all projects |
| `resource-count-oci.py` | 2.8.0 | OCI | Counts resources across compartments |

All scripts support optional flags: `--ai` (AI/LLM resources), `--data` (buckets, databases), `--images` (container registry images).

## GCP Vertex AI Models merged

The existing `gcp-vertex/gcp-vertex-model-count.sh` counted Vertex AI Models via bash. This is now merged into `resource-count-gcp-v2.py` under the `--ai` flag as `Vertex AI Models` — alongside the existing Vertex AI Endpoints and Vertex AI Agents. The bash script is superseded.

## What's not committed

- `*.csv` output files (runtime output)
- `projects.txt` / `subscriptions.txt` (contain real account IDs)
- `.venv/` and `__pycache__/`

A `.gitignore` is included to prevent these from being accidentally committed.

## Author
Yash Jhunjhunwala, Lead SME Cloud Security Solutions