### PR TITLE
feat: Azure TenantConnector — CPS perimeter scan, update subcommand, input validation

### DIFF
--- a/Connectors/Azure/README.md
+++ b/Connectors/Azure/README.md
@@ -2,7 +2,7 @@
 
 Four tools depending on what you need:
 
-**[`TenantConnector/`](TenantConnector/)** — if you want full automation. It discovers every subscription in your tenant, creates connectors, handles orphan detection when subscriptions disappear, and can restore disabled connectors. Works for both Azure Commercial and Azure Government. This is the recommended path for most deployments.
+**[`TenantConnector/`](TenantConnector/)** — if you want full automation. It discovers every subscription in your tenant, creates connectors, updates them when settings change, handles orphan detection when subscriptions disappear, and can restore disabled connectors. Supports perimeter scan (CPS), custom scan schedules, and both Azure Commercial and Azure Government. This is the recommended path for most deployments.
 
 **[`SubscriptionConnector/`](SubscriptionConnector/)** — simpler Bash script if you already have a list of subscription IDs and just want to create connectors for them.
 

--- a/Connectors/Azure/TenantConnector/.gitignore
+++ b/Connectors/Azure/TenantConnector/.gitignore
@@ -9,6 +9,12 @@ connector_delete_*.csv
 connector_orphans_*.csv
 connector_restore_*.csv
 connector_report_*.json
+connectors.csv
+
+# Live test run output (contains logs, CSVs, and per-test config.json with credentials)
+_lt_run_*/
+_live_test.py
+.claude/
 
 # Python
 __pycache__/

--- a/Connectors/Azure/TenantConnector/README.md
+++ b/Connectors/Azure/TenantConnector/README.md
@@ -1,6 +1,6 @@
 # Azure → Qualys Tenant Connector
 
-A Python CLI that discovers every active subscription in an Azure tenant and automatically creates a Qualys cloud connector for each one. Supports **Azure Government** and **Azure Commercial** clouds, all 14 Qualys platforms, and full lifecycle management (create, list, status, disable orphans, restore, delete).
+A Python CLI that discovers every active subscription in an Azure tenant and automatically creates, updates, and deletes Qualys cloud connectors for each one. Supports **Azure Government** and **Azure Commercial** clouds, all 14 Qualys platforms, and full lifecycle management (create, update, list, status, disable orphans, restore, delete).
 
 ---
 
@@ -12,10 +12,12 @@ A Python CLI that discovers every active subscription in an Azure tenant and aut
 - [Configuration](#configuration)
   - [Azure Section](#azure-section)
   - [Qualys Section](#qualys-section)
+  - [Perimeter Scan Config](#perimeter-scan-config)
   - [Qualys Platforms](#qualys-platforms)
 - [CLI Reference](#cli-reference)
   - [Global Flags](#global-flags)
   - [create](#create)
+  - [update](#update)
   - [list](#list)
   - [status](#status)
   - [list-mgs](#list-mgs)
@@ -40,8 +42,9 @@ Azure Tenant
 3. Collects all active subscriptions
 4. For each subscription, calls the Qualys Connectors API to create an `AzureAssetDataConnector`
 5. Skips subscriptions that already have a connector (idempotent)
-6. Optionally resolves/creates Qualys tags and applies them to connectors and discovered assets
-7. Fetches live connector state after creation and saves everything to CSV
+6. Optionally enables Perimeter Scan (CPS) with a global or custom schedule
+7. Optionally resolves/creates Qualys tags and applies them to connectors
+8. Fetches live connector state after creation and saves everything to `connectors.csv`
 
 ---
 
@@ -81,7 +84,7 @@ If the SP only has `Reader` on individual subscriptions, the script falls back t
 
 ```bash
 git clone <repo-url>
-cd azure-gov-tenant-connector
+cd TenantConnector
 
 # Create virtual environment
 python -m venv .venv
@@ -140,7 +143,18 @@ All runtime settings live in `config.json`. The only CLI arguments are `--config
     "isGovCloud":     false,
     "disableOrphans": false,
     "connectorTags":  ["azure-commercial", "production"],
-    "assetTags":      ["azure-asset", "cloud-discovery"]
+    "connectorNamePrefix": "",
+    "connectorNameSuffix": "",
+    "perimeterScan":  false,
+    "perimeterScanConfig": {
+      "optionProfileId": 12345,
+      "recurrence":      "WEEKLY",
+      "daysOfWeek":      ["SUN"],
+      "startDate":       "01/01/2025",
+      "startTime":       "02:00",
+      "timezone":        "UTC",
+      "scanPrefix":      "Azure Scan"
+    }
   }
 }
 ```
@@ -161,13 +175,50 @@ All runtime settings live in `config.json`. The only CLI arguments are `--config
 | `username` | **Yes** | — | Qualys login username |
 | `password` | **Yes** | — | Qualys login password |
 | `platform` | **Yes** | — | Qualys platform key (e.g. `"US2"`) or a full base URL. See [Qualys Platforms](#qualys-platforms). |
-| `appType` | No | `"cspm"` | Connector type. `"cspm"` enables Cloud Security Assessment; `"asset-inventory"` enables asset discovery only. |
-| `activation` | No | `[]` (none) | List of Qualys modules to activate. Valid values: `VM` (Vulnerability Management), `PC` (Policy Compliance), `SCA` (Security Configuration Assessment), `CERTVIEW`. **Note:** `PC` and `SCA` are mutually exclusive — choose one. |
-| `runFrequency` | No | `1440` | How often Qualys syncs the connector, in minutes. Default is 1440 (24 hours). |
+| `appType` | No | `"cspm"` | Connector type. `"cspm"` enables AI + Cloud Inventory + Cloud Security Assessment. `"asset-inventory"` enables Asset Inventory only. |
+| `activation` | No | `[]` (none) | Qualys modules to activate on the connector. Valid values: `VM` (Vulnerability Management), `PC` (Policy Compliance), `SCA` (Security Configuration Assessment), `CERTVIEW`. **Note:** `PC` and `SCA` are mutually exclusive. |
+| `runFrequency` | No | `1440` | How often Qualys syncs the connector, in minutes. Must be one of: `60`, `120`, `180`, `240`, `360`, `480`, `720`, `1440`. |
 | `isGovCloud` | No | `true` | `true` = Azure Government (`login.microsoftonline.us`). `false` = Azure Commercial (`login.microsoftonline.com`). |
 | `disableOrphans` | No | `false` | When `true`, connectors for subscriptions no longer in scope are automatically disabled on each `create` run. See [Orphan Detection](#orphan-detection). |
-| `connectorTags` | No | `[]` | Tag names to apply to the **connector object** in Qualys. Tags are created automatically if they don't exist. |
-| `assetTags` | No | `[]` | Tag names to apply to **assets discovered** by the connector. |
+| `connectorTags` | No | `[]` | Tag names to apply to the connector object in Qualys. Created automatically if they don't exist. |
+| `connectorNamePrefix` | No | `""` | String prepended to every connector name. Useful for environment labelling (e.g. `"prod-"`). |
+| `connectorNameSuffix` | No | `""` | String appended to every connector name. |
+| `perimeterScan` | No | `false` | Enable Qualys Perimeter Scan (CPS) on each connector. Requires `"VM"` in `activation`. |
+| `perimeterScanConfig` | No | `null` | Custom scan schedule. When `null` (or omitted), the Qualys global scan schedule is used. See [Perimeter Scan Config](#perimeter-scan-config). |
+
+### Perimeter Scan Config
+
+When `perimeterScan: true` and you want your own schedule instead of the Qualys global default, provide `perimeterScanConfig`:
+
+| Field | Required | Description |
+|---|---|---|
+| `optionProfileId` | **Yes** | ID of a VM option profile in your Qualys account. Find it under Scans → Option Profiles in the Qualys UI. Must be a positive integer. |
+| `recurrence` | **Yes** | `"WEEKLY"` or `"MONTHLY"`. |
+| `daysOfWeek` | Yes (when `WEEKLY`) | Array of day abbreviations: `"SUN"`, `"MON"`, `"TUE"`, `"WED"`, `"THU"`, `"FRI"`, `"SAT"`. |
+| `startDate` | **Yes** | Scan window start date in `MM/DD/YYYY` format. |
+| `startTime` | **Yes** | Scan window start time in `HH:MM` (24-hour) format. |
+| `timezone` | **Yes** | Timezone name (e.g. `"UTC"`, `"America/New_York"`). |
+| `scanPrefix` | No | Prefix applied to scan job names in Qualys (e.g. `"Azure Scan"`). |
+
+**Global schedule (no custom config):**
+```json
+"perimeterScan": true,
+"perimeterScanConfig": null
+```
+
+**Custom weekly schedule:**
+```json
+"perimeterScan": true,
+"perimeterScanConfig": {
+  "optionProfileId": 12345,
+  "recurrence":      "WEEKLY",
+  "daysOfWeek":      ["SUN"],
+  "startDate":       "01/01/2025",
+  "startTime":       "02:00",
+  "timezone":        "UTC",
+  "scanPrefix":      "Azure Scan"
+}
+```
 
 ### Qualys Platforms
 
@@ -209,7 +260,7 @@ python main.py [--config FILE] [--output-dir DIR] <command> [options]
 | Flag | Default | Description |
 |---|---|---|
 | `--config FILE` | `config.json` | Path to your config file |
-| `--output-dir DIR` | `.` (current directory) | Directory where all CSVs and logs are written. Created automatically if it doesn't exist. Useful for organising runs by date or environment. |
+| `--output-dir DIR` | `.` (current directory) | Directory where `connectors.csv` and logs are written. Created automatically if it doesn't exist. |
 
 ---
 
@@ -223,13 +274,13 @@ python main.py create [--dry-run] [--parallel N]
 
 | Flag | Default | Description |
 |---|---|---|
-| `--dry-run` | off | Enumerate Azure subscriptions only. No Qualys API calls are made. Useful for previewing scope before a live run. |
-| `--parallel N` | `1` | Number of concurrent connector creation threads. Default is 1 (sequential). Submissions are always paced 2 seconds apart regardless of parallelism to avoid Qualys rate limits. |
+| `--dry-run` | off | Enumerate Azure subscriptions only — no Qualys API calls. Useful for previewing scope before a live run. |
+| `--parallel N` | `1` | Number of concurrent connector creation threads. Submissions are paced 2 seconds apart to avoid rate limits. |
 
 **Behaviour:**
 - Skips subscriptions that already have a connector (idempotent — safe to re-run)
 - If `disableOrphans: true`, runs orphan detection **before** creating new connectors
-- Fetches live connector state after creation and saves to CSV
+- Fetches live connector state after creation and saves to `connectors.csv`
 
 **Examples:**
 
@@ -251,10 +302,10 @@ python main.py --config config-dev.json  --output-dir runs/dev  create
 **Sample output:**
 
 ```
-  #    Subscription ID                        Connector Name                             MG
-  ─────────────────────────────────────────────────────────────────────────────────────────
-  1    aaa-bbb-ccc-ddd-...                    My Production Sub                          prod-mg
-  2    eee-fff-ggg-hhh-...                    Dev Environment                            dev-mg
+  #    Subscription ID                        Connector Name                   MG
+  ─────────────────────────────────────────────────────────────────────────────
+  1    aaa-bbb-ccc-ddd-...                    My Production Sub                prod-mg
+  2    eee-fff-ggg-hhh-...                    Dev Environment                  dev-mg
 
 =================================================================
   Summary — 2026-05-18 16:30 UTC
@@ -272,6 +323,47 @@ python main.py --config config-dev.json  --output-dir runs/dev  create
 
 ---
 
+### `update`
+
+Updates all connectors tracked in `connectors.csv` to match the current config (activation modules, run frequency, perimeter scan settings, etc.).
+
+```bash
+python main.py update --all
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--all` | **Yes** | Confirms you want to update all connectors in `connectors.csv`. The script prompts for confirmation before proceeding. |
+
+**Behaviour:**
+- Reads connector IDs from `connectors.csv` in the output directory
+- Prompts `Update all N connector(s)? [y/N]` before making any API calls
+- Updates every connector to match the current `config.json` settings
+- Updates `connectors.csv` with the new status
+
+**Example:**
+
+```bash
+# Update all connectors to the current config
+python main.py update --all
+
+# Use a specific output dir (where connectors.csv lives)
+python main.py --output-dir runs/prod update --all
+```
+
+**Sample output:**
+
+```
+  Updating 2 connector(s) …
+
+  ✓ [657901] My Production Sub updated
+  ✓ [657902] Dev Environment updated
+
+  Summary: 2 updated, 0 failed
+```
+
+---
+
 ### `list`
 
 Lists all Azure connectors currently in Qualys with their live state.
@@ -282,15 +374,12 @@ python main.py list [--subscription ID]
 
 | Flag | Default | Description |
 |---|---|---|
-| `--subscription ID` | (all) | Filter results to connectors whose subscription ID contains this string (substring match) |
+| `--subscription ID` | (all) | Filter to connectors whose subscription ID contains this string (substring match) |
 
 **Example:**
 
 ```bash
-# List all
 python main.py list
-
-# Filter to a specific subscription
 python main.py list --subscription aaa-bbb-ccc
 ```
 
@@ -348,7 +437,7 @@ python main.py status --ids 657901 657902
 
 ### `list-mgs`
 
-Prints the Management Group hierarchy for your tenant as a tree. Use this to find the right value for `azure.rootMg` in your config.
+Prints the Management Group hierarchy for your tenant as a tree. Use this to find the right value for `azure.rootMg`.
 
 ```bash
 python main.py list-mgs
@@ -375,16 +464,26 @@ The name in `[brackets]` is what you put in `azure.rootMg`.
 
 ### `delete`
 
-Permanently deletes one or more Qualys connectors by ID. This cannot be undone.
+Permanently deletes Qualys connectors. This cannot be undone.
 
 ```bash
+# Delete specific connectors by ID
 python main.py delete --ids <ID> [<ID> ...]
+
+# Delete all connectors tracked in connectors.csv
+python main.py delete --all
 ```
 
-**Example:**
+| Flag | Description |
+|---|---|
+| `--ids ID [ID ...]` | Delete specific connector IDs |
+| `--all` | Delete all connectors in `connectors.csv`. Prompts for confirmation. |
+
+**Examples:**
 
 ```bash
 python main.py delete --ids 657901 657902
+python main.py --output-dir runs/prod delete --all
 ```
 
 **Sample output:**
@@ -408,7 +507,7 @@ Re-enables connectors that were previously disabled by this script (via `disable
 python main.py restore-orphans
 ```
 
-This reads `connector_orphans_*.csv` history, discovers the current active Azure subscriptions, and re-enables any connector whose subscription is now back in scope. See [Orphan Detection](#orphan-detection) for the full explanation.
+See [Orphan Detection](#orphan-detection) for the full explanation.
 
 ---
 
@@ -416,53 +515,36 @@ This reads `connector_orphans_*.csv` history, discovers the current active Azure
 
 ### What is an orphan?
 
-An orphan is a Qualys connector whose Azure subscription is **no longer in scope** — because the subscription was deleted, moved out of the managed Management Group, or you narrowed `azure.rootMg` in your config.
+An orphan is a Qualys connector whose Azure subscription is **no longer in scope** — because the subscription was deleted, moved out of the managed Management Group, or you narrowed `azure.rootMg`.
 
-Without cleanup, orphaned connectors keep running sync jobs in Qualys against subscriptions that are no longer managed, consuming resources and polluting your asset inventory.
+Without cleanup, orphaned connectors keep syncing against subscriptions that are no longer managed, consuming resources and polluting your asset inventory.
 
 ### How it works
 
 Enable with `"disableOrphans": true` in config. On every `create` run, **before** creating new connectors, the script:
 
-1. Reads all `connector_state_*.csv` files to identify the set of connectors **this script created** (by connector ID)
+1. Reads `connectors.csv` to identify connectors this script created (by connector ID)
 2. Fetches the current list of connectors from Qualys
 3. Filters to only script-managed connectors (all others are untouched)
 4. Disables any script-managed connector whose subscription is not in the current Azure scope
-
-```
-Script-managed connector IDs (from CSV history)
-    ∩  connectors whose subscription is not in current Azure scope
-    ∩  connectors that are not already disabled
-    →  these are disabled
-```
 
 ### What it does NOT touch
 
 - Connectors created outside this script (e.g. manually, by another tool)
 - Connectors that are already disabled
-- Connectors in Qualys for other cloud types (AWS, GCP)
+- Connectors for other cloud types (AWS, GCP)
 
 ### Safety guard
 
-If no `connector_state_*.csv` history exists (first run on a new machine, or files were deleted), orphan detection **skips entirely** with a warning:
-
-```
-WARNING: Orphan detection requested but no CSV history found.
-Skipping to avoid touching connectors created outside this script.
-Run 'create' at least once so the script has a baseline.
-```
-
-This prevents the script from accidentally disabling connectors it didn't create.
+If no `connectors.csv` history exists (first run, or files deleted), orphan detection **skips entirely** with a warning. This prevents accidentally disabling connectors created outside this script.
 
 ### Restoring orphans
-
-If a subscription comes back (or you expand `rootMg`), restore its connector:
 
 ```bash
 python main.py restore-orphans
 ```
 
-The script cross-references the `connector_orphans_*.csv` disable history against the current active Azure subscriptions and re-enables matching connectors. A `connector_restore_*.csv` is written with the results.
+Cross-references the orphan disable history against the current active Azure subscriptions and re-enables any connector whose subscription is now back in scope.
 
 ### Example walkthrough
 
@@ -475,14 +557,10 @@ Step 2: rootMg = "QA"  (2 subscriptions: D, E)
         → create runs:
             orphan check: A, B, C are no longer in scope → DISABLED
             D, E already exist → skipped
-        → connector_orphans_<ts>.csv written
 
 Step 3: rootMg = null (5 subscriptions again)
         → restore-orphans:
-            reads orphan CSV: A, B, C were disabled
-            checks Azure: A, B, C subscriptions are active again
-            → A, B, C RE-ENABLED
-        → connector_restore_<ts>.csv written
+            A, B, C subscriptions are active again → RE-ENABLED
 ```
 
 ---
@@ -493,13 +571,13 @@ All files are written to `--output-dir` (default: current directory). Logs go in
 
 | File | Created by | Contents |
 |---|---|---|
-| `connector_state_<ts>.csv` | `create` | Full record of every subscription processed: connector ID, status, and live state snapshot (connectorState, lastSyncedOn, asset counts) |
+| `connectors.csv` | `create`, `update`, `delete` | Primary state file — connector IDs, status, and live state snapshot. Read by `update --all` and `delete --all`. |
 | `connector_orphans_<ts>.csv` | `create` (with disableOrphans) | Record of connectors disabled by orphan detection |
 | `connector_restore_<ts>.csv` | `restore-orphans` | Record of connectors re-enabled |
-| `connector_delete_<ts>.csv` | `delete` | Audit log of manual deletions |
+| `connector_delete_<ts>.csv` | `delete` | Audit log of deletions |
 | `logs/run_<ts>.log` | all commands | Full timestamped log of every API call and decision |
 
-### `connector_state_*.csv` columns
+### `connectors.csv` columns
 
 | Column | Description |
 |---|---|
@@ -512,7 +590,7 @@ All files are written to `--output-dir` (default: current directory). Logs go in
 | `management_group` | Parent MG name |
 | `connector_name` | Name given to the Qualys connector |
 | `connector_id` | Qualys connector ID |
-| `status` | `created`, `skipped`, `failed`, or `dry_run` |
+| `status` | `created`, `updated`, `skipped`, `failed`, `deleted`, or `dry_run` |
 | `note` | Error message (if failed) or `already_exists` (if skipped) |
 | `connector_state` | Live state from Qualys (e.g. `FINISHED_SUCCESS`) |
 | `last_synced_on` | Timestamp of last successful sync |
@@ -530,29 +608,26 @@ All files are written to `--output-dir` (default: current directory). Logs go in
 | Topic | Guidance |
 |---|---|
 | `config.json` | Contains Azure SP secret and Qualys credentials. Never commit to version control. The script warns at startup if the file is not gitignored. |
-| SP Secret rotation | The SP secret is stored as `authenticationKey` inside each Qualys connector's `authRecord`. If you rotate the secret, update `config.json` **and** update existing connectors in Qualys (or delete and re-create them). |
+| SP Secret rotation | The SP secret is stored inside each Qualys connector's `authRecord`. If you rotate the secret, update `config.json` **and** run `update --all` to push the new key to all connectors. |
 | Qualys credentials | Transmitted over HTTPS (Basic Auth). Use a Qualys service account with the minimum role needed to manage connectors. |
 | Least privilege | The Azure SP only needs read access to Management Groups and Subscriptions — no write access to Azure resources. |
-| Output files | `connector_state_*.csv` files contain subscription IDs and connector IDs but no secrets. They are safe to retain for audit purposes. |
+| Output files | `connectors.csv` contains subscription IDs and connector IDs but no secrets. Safe to retain for audit purposes. |
 
 ---
 
 ## Project Structure
 
 ```
-azure-gov-tenant-connector/
+TenantConnector/
 ├── main.py              # CLI entry point — all commands, config loading, CSV output
 ├── azure_client.py      # Azure MG/subscription discovery (Gov + Commercial)
-├── qualys_client.py     # Qualys Connectors API client (create, search, update, delete)
+├── qualys_client.py     # Qualys Connectors API client (create, update, delete, search)
 ├── config.json          # Your credentials and settings (gitignored)
 ├── config.example.json  # Full schema reference with all fields and defaults
 ├── requirements.txt     # Python dependencies
 ├── .gitignore           # Excludes config.json, CSVs, logs, .venv
-├── logs/                # Per-run log files
-├── connector_state_*.csv
-├── connector_orphans_*.csv
-├── connector_restore_*.csv
-└── connector_delete_*.csv
+├── connectors.csv       # Primary connector state file (gitignored)
+└── logs/                # Per-run log files (gitignored)
 ```
 
 ---
@@ -561,15 +636,19 @@ azure-gov-tenant-connector/
 
 **What happens if I run `create` twice?**
 
-Nothing bad. The script checks whether a connector already exists for each subscription before creating one. Duplicates are skipped and reported as `Already existed` in the summary. It is safe to run on a schedule.
+Nothing bad. The script checks whether a connector already exists for each subscription before creating one. Duplicates are skipped and reported as `Already existed`. It is safe to run on a schedule.
+
+**How do I change settings (e.g. enable perimeter scan) on existing connectors?**
+
+Update `config.json` with your new settings, then run `update --all`. It will push the new settings to all connectors in `connectors.csv`.
 
 **Can I use a different config file per environment?**
 
-Yes. Use `--config`:
+Yes. Use `--config` and `--output-dir` to keep environments isolated:
 
 ```bash
-python main.py --config config-gov-prod.json create
-python main.py --config config-commercial-dev.json create
+python main.py --config config-prod.json --output-dir runs/prod create
+python main.py --config config-dev.json  --output-dir runs/dev  create
 ```
 
 **Can I scope to a specific MG without changing the config?**
@@ -586,8 +665,12 @@ Qualys enforces a 255-character limit. The script automatically truncates names 
 
 **My run was interrupted mid-way. What do I do?**
 
-Re-run `create`. Connectors already created will be skipped (idempotent). The run will pick up where it left off effectively.
+Re-run `create`. Connectors already created will be skipped (idempotent). The run will resume effectively from where it left off.
 
-**I deleted `connector_state_*.csv` files. Will orphan detection break?**
+**I deleted `connectors.csv`. Will orphan detection or `update --all` break?**
 
-It will skip orphan detection and print a warning (the safety guard). Run `create` once normally to rebuild the history, then orphan detection will work on the next run.
+Orphan detection will skip with a warning (safety guard). `update --all` and `delete --all` will have no connectors to act on. Run `create` once to rebuild `connectors.csv`.
+
+**Which `runFrequency` values are valid?**
+
+Qualys accepts: `60`, `120`, `180`, `240`, `360`, `480`, `720`, `1440` minutes. The script validates this at startup and exits with a clear error if an unsupported value is used.

--- a/Connectors/Azure/TenantConnector/config.example.json
+++ b/Connectors/Azure/TenantConnector/config.example.json
@@ -12,13 +12,26 @@
 
     "platform":       "US2",
 
-    "appType":        "cspm",
+    "appModules":     ["AI", "CI", "CSA"],
     "activation":     ["VM", "PC"],
     "runFrequency":   1440,
     "isGovCloud":     false,
     "disableOrphans": false,
 
     "connectorTags":  ["azure-commercial", "production"],
-    "assetTags":      ["azure-asset", "cloud-discovery"]
+
+    "connectorNamePrefix": "",
+    "connectorNameSuffix": "",
+
+    "perimeterScan":  false,
+    "perimeterScanConfig": {
+      "optionProfileId": 2,
+      "recurrence":      "WEEKLY",
+      "daysOfWeek":      ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"],
+      "startDate":       "01/01/2025",
+      "startTime":       "02:00",
+      "timezone":        "UTC",
+      "scanPrefix":      "Azure Scan"
+    }
   }
 }

--- a/Connectors/Azure/TenantConnector/config.example.json
+++ b/Connectors/Azure/TenantConnector/config.example.json
@@ -12,7 +12,7 @@
 
     "platform":       "US2",
 
-    "appModules":     ["AI", "CI", "CSA"],
+    "appType":        "cspm",
     "activation":     ["VM", "PC"],
     "runFrequency":   1440,
     "isGovCloud":     false,

--- a/Connectors/Azure/TenantConnector/main.py
+++ b/Connectors/Azure/TenantConnector/main.py
@@ -32,7 +32,6 @@ from azure_client import (
     list_management_groups,
 )
 from qualys_client import (
-    APP_TYPE_CONFIG,
     ConnectorResult,
     QualysClient,
     VALID_ACTIVATION_MODULES,
@@ -43,25 +42,21 @@ from qualys_client import (
 _LOG_FMT  = "%(asctime)s  %(levelname)-7s  %(message)s"
 _LOG_DATE = "%Y-%m-%d %H:%M:%S"
 
-_APP_TYPE_MAP = {
-    "asset-inventory": "AI",
-    "cspm":            "CSA",
-}
-
 _DELETE_PATH = "/qps/rest/3.0/delete/am/azureassetdataconnector"
 
 
 # ── logging ───────────────────────────────────────────────────────────────────
 
-def _setup_logging(output_dir: Path) -> Path:
+def _setup_logging(output_dir: Path, verbose: bool = False) -> Path:
     log_dir = output_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"run_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}.log"
 
     root = logging.getLogger()
-    root.setLevel(logging.INFO)
+    root.setLevel(logging.DEBUG if verbose else logging.INFO)
 
     console = logging.StreamHandler(sys.stdout)
+    console.setLevel(logging.DEBUG if verbose else logging.INFO)
     console.setFormatter(logging.Formatter(_LOG_FMT, datefmt="%H:%M:%S"))
     root.addHandler(console)
 
@@ -143,11 +138,6 @@ def _qualys_settings(cfg: dict) -> dict:
         log.error("%s", exc)
         sys.exit(1)
 
-    raw_app_type = q.get("appType", "cspm").lower()
-    if raw_app_type not in _APP_TYPE_MAP:
-        log.error("Config qualys.appType must be one of: %s", list(_APP_TYPE_MAP))
-        sys.exit(1)
-
     activation = q.get("activation") or []
     invalid = [m for m in activation if m not in VALID_ACTIVATION_MODULES]
     if invalid:
@@ -161,24 +151,61 @@ def _qualys_settings(cfg: dict) -> dict:
         log.error("Config qualys.activation: PC and SCA cannot be activated together — choose one.")
         sys.exit(1)
 
+    _VALID_FREQUENCIES = {60, 120, 180, 240, 360, 480, 720, 1440}
     run_frequency = int(q.get("runFrequency", 1440))
-    if run_frequency < 1:
-        log.error("Config qualys.runFrequency must be >= 1 minute")
+    if run_frequency not in _VALID_FREQUENCIES:
+        log.error(
+            "Config qualys.runFrequency=%d is invalid. Allowed values: %s",
+            run_frequency, sorted(_VALID_FREQUENCIES),
+        )
         sys.exit(1)
+
+    perimeter_scan = bool(q.get("perimeterScan", False))
+    scan_config    = q.get("perimeterScanConfig") or None
+
+    _VALID_APP_MODULES = {"AI", "CI", "CSA"}
+    raw_app_modules = q.get("appModules") or []
+    app_modules = [m.upper() for m in raw_app_modules]
+    bad_mods = [m for m in app_modules if m not in _VALID_APP_MODULES]
+    if bad_mods:
+        log.error("Config qualys.appModules contains invalid values: %s  (valid: AI, CI, CSA)", bad_mods)
+        sys.exit(1)
+
+    # CSA and CI both require the full AI+CI+CSA bundle
+    if ("CSA" in app_modules or "CI" in app_modules):
+        if not {"AI", "CI", "CSA"}.issubset(set(app_modules)):
+            log.error(
+                "Config qualys.appModules: CI and CSA must always be enabled together with AI (use [\"AI\",\"CI\",\"CSA\"])."
+            )
+            sys.exit(1)
+
+    if perimeter_scan and "VM" not in activation:
+        log.error("Config: perimeterScan=true requires \"VM\" in qualys.activation.")
+        sys.exit(1)
+
+    if perimeter_scan and scan_config:
+        valid_days = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}
+        bad_days   = [d for d in (scan_config.get("daysOfWeek") or []) if d not in valid_days]
+        if bad_days:
+            log.error("perimeterScanConfig.daysOfWeek contains invalid values: %s  (valid: %s)",
+                      bad_days, sorted(valid_days))
+            sys.exit(1)
 
     return {
         "username":        q["username"],
         "password":        q["password"],
         "base_url":        base_url,
         "platform_label":  platform_val.upper() if not platform_val.startswith("http") else "custom",
-        "app_type_label":  raw_app_type,
-        "app_type_key":    _APP_TYPE_MAP[raw_app_type],
         "activation":      activation,
         "run_frequency":   run_frequency,
         "is_gov_cloud":    bool(q.get("isGovCloud", True)),
         "disable_orphans": bool(q.get("disableOrphans", False)),
         "connector_tags":  q.get("connectorTags") or [],
-        "asset_tags":      q.get("assetTags") or [],
+        "name_prefix":     q.get("connectorNamePrefix") or "",
+        "name_suffix":     q.get("connectorNameSuffix") or "",
+        "perimeter_scan":  perimeter_scan,
+        "scan_config":     scan_config,
+        "app_modules":     app_modules,
     }
 
 
@@ -190,81 +217,141 @@ def _qualys_client(qs: dict) -> QualysClient:
     )
 
 
-# ── CSV / summary ─────────────────────────────────────────────────────────────
+# ── CSV ──────────────────────────────────────────────────────────────────────
 
-def _ts() -> str:
-    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+_CSV_FILE = "connectors.csv"
+_CSV_FIELDS = [
+    "subscription_id", "subscription_name", "management_group",
+    "connector_id", "connector_name", "tenant_id", "app_type", "dry_run",
+    "created_at", "last_updated_at", "last_action", "current_status", "note",
+    "connector_state", "last_synced_on",
+    "total_assets_created", "total_assets_updated", "total_assets_deleted",
+    "connector_error", "disabled", "run_frequency",
+]
 
 
-def _save_csv(
+def _load_connector_csv(output_dir: Path) -> tuple[dict[str, dict], dict[str, dict]]:
+    """
+    Load connectors.csv. Returns (by_sub, by_id) — both dicts share the same row objects.
+    """
+    by_sub: dict[str, dict] = {}
+    by_id:  dict[str, dict] = {}
+    path = output_dir / _CSV_FILE
+    if not path.exists():
+        return by_sub, by_id
+    with path.open(newline="") as fh:
+        for row in csv.DictReader(fh):
+            sub_id = row.get("subscription_id", "")
+            cid    = row.get("connector_id", "")
+            if sub_id:
+                by_sub[sub_id] = row
+            if cid:
+                by_id[cid] = row
+    log.info("Loaded %d row(s) from %s", len(by_sub), path)
+    return by_sub, by_id
+
+
+def _write_connector_csv(by_sub: dict[str, dict], by_id: dict[str, dict], output_dir: Path) -> Path:
+    path = output_dir / _CSV_FILE
+    seen: set[int] = set()
+    rows: list[dict] = []
+    for row in list(by_sub.values()) + list(by_id.values()):
+        if id(row) not in seen:
+            seen.add(id(row))
+            rows.append(row)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_CSV_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({f: row.get(f, "") for f in _CSV_FIELDS})
+    return path
+
+
+def _upsert_create_results(
     results: list[ConnectorResult],
     tenant_id: str,
-    app_type_label: str,
+    label: str,
     dry_run: bool,
     output_dir: Path,
     states: Optional[dict[str, dict]] = None,
 ) -> Path:
-    filename = output_dir / f"connector_state_{_ts()}.csv"
-    fieldnames = [
-        "timestamp", "tenant_id", "app_type", "dry_run",
-        "subscription_id", "subscription_name", "management_group",
-        "connector_name", "connector_id", "status", "note",
-        "connector_state", "last_synced_on",
-        "total_assets_created", "total_assets_updated", "total_assets_deleted",
-        "connector_error", "disabled", "run_frequency",
-    ]
-    now = datetime.now(timezone.utc).isoformat()
+    by_sub, by_id = _load_connector_csv(output_dir)
+    now    = datetime.now(timezone.utc).isoformat()
     states = states or {}
-    with open(filename, "w", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=fieldnames)
-        writer.writeheader()
-        for r in results:
-            st = states.get(r.connector_id or "", {})
-            writer.writerow({
-                "timestamp":            now,
-                "tenant_id":            tenant_id,
-                "app_type":             app_type_label,
-                "dry_run":              str(dry_run).lower(),
-                "subscription_id":      r.subscription_id,
-                "subscription_name":    r.subscription_name,
-                "management_group":     r.management_group,
-                "connector_name":       r.connector_name,
-                "connector_id":         r.connector_id or "",
-                "status":               r.status,
-                "note":                 r.note or "",
-                "connector_state":      st.get("connector_state", ""),
-                "last_synced_on":       st.get("last_synced_on", ""),
-                "total_assets_created": st.get("total_assets_created", ""),
-                "total_assets_updated": st.get("total_assets_updated", ""),
-                "total_assets_deleted": st.get("total_assets_deleted", ""),
-                "connector_error":      st.get("connector_error", ""),
-                "disabled":             st.get("disabled", ""),
-                "run_frequency":        st.get("run_frequency", ""),
-            })
-    return filename
+
+    for r in results:
+        st       = states.get(r.connector_id or "", {})
+        existing = by_sub.get(r.subscription_id, {})
+
+        if r.status in ("created", "updated"):
+            current_status = "active"
+        elif r.status == "skipped":
+            current_status = existing.get("current_status") or "active"
+        elif r.status == "dry_run":
+            current_status = "dry_run"
+        else:
+            current_status = "failed"
+
+        row: dict = {
+            "subscription_id":      r.subscription_id,
+            "subscription_name":    r.subscription_name,
+            "management_group":     r.management_group,
+            "connector_id":         r.connector_id or existing.get("connector_id", ""),
+            "connector_name":       r.connector_name,
+            "tenant_id":            tenant_id,
+            "app_type":             label,
+            "dry_run":              str(dry_run).lower(),
+            "created_at":           existing.get("created_at") or now,
+            "last_updated_at":      now,
+            "last_action":          r.status,
+            "current_status":       current_status,
+            "note":                 r.note or "",
+            "connector_state":      st.get("connector_state",       existing.get("connector_state", "")),
+            "last_synced_on":       st.get("last_synced_on",        existing.get("last_synced_on", "")),
+            "total_assets_created": st.get("total_assets_created",  existing.get("total_assets_created", "")),
+            "total_assets_updated": st.get("total_assets_updated",  existing.get("total_assets_updated", "")),
+            "total_assets_deleted": st.get("total_assets_deleted",  existing.get("total_assets_deleted", "")),
+            "connector_error":      st.get("connector_error",       existing.get("connector_error", "")),
+            "disabled":             st.get("disabled",              existing.get("disabled", "")),
+            "run_frequency":        st.get("run_frequency",         existing.get("run_frequency", "")),
+        }
+        by_sub[r.subscription_id] = row
+        if row["connector_id"]:
+            by_id[row["connector_id"]] = row
+
+    return _write_connector_csv(by_sub, by_id, output_dir)
 
 
-def _save_orphan_csv(orphans: list[dict], output_dir: Path) -> Path:
-    filename = output_dir / f"connector_orphans_{_ts()}.csv"
-    fieldnames = ["timestamp", "connector_id", "connector_name", "subscription_id", "result", "note"]
+def _apply_action(
+    connector_id: str,
+    action: str,
+    current_status: str,
+    note: str,
+    by_sub: dict[str, dict],
+    by_id:  dict[str, dict],
+) -> None:
+    """Update an existing row, or create a minimal one if the connector isn't in history."""
     now = datetime.now(timezone.utc).isoformat()
-    with open(filename, "w", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=fieldnames)
-        writer.writeheader()
-        for o in orphans:
-            writer.writerow({
-                "timestamp":       now,
-                "connector_id":    o["id"],
-                "connector_name":  o["name"],
-                "subscription_id": o["subscriptionId"],
-                "result":          o["result"],
-                "note":            o.get("note", ""),
-            })
-    return filename
+    row = by_id.get(connector_id)
+    if row is None:
+        row = {"connector_id": connector_id, "created_at": ""}
+        by_id[connector_id] = row
+        sub_id = row.get("subscription_id", "")
+        if sub_id:
+            by_sub[sub_id] = row
+    row["last_updated_at"] = now
+    row["last_action"]     = action
+    row["current_status"]  = current_status
+    row["note"]            = note
+    if action in ("disabled", "orphan_disable"):
+        row["disabled"] = "true"
+    elif action in ("enabled", "created"):
+        row["disabled"] = "false"
 
 
 def _print_summary(results: list[ConnectorResult]) -> None:
     created = [r for r in results if r.status == "created"]
+    updated = [r for r in results if r.status == "updated"]
     skipped = [r for r in results if r.status == "skipped"]
     dry     = [r for r in results if r.status == "dry_run"]
     failed  = [r for r in results if r.status == "failed"]
@@ -277,11 +364,13 @@ def _print_summary(results: list[ConnectorResult]) -> None:
         print(f"  Dry-run (enum) : {len(dry)}")
     else:
         print(f"  Created        : {len(created)}")
+        print(f"  Updated        : {len(updated)}")
         print(f"  Already existed: {len(skipped)}")
         print(f"  Failed         : {len(failed)}")
 
     for label, bucket, icon in [
         ("Created", created, "✓"),
+        ("Updated", updated, "↺"),
         ("Skipped", skipped, "↷"),
         ("Dry-run", dry,     "○"),
         ("Failed",  failed,  "✗"),
@@ -295,59 +384,18 @@ def _print_summary(results: list[ConnectorResult]) -> None:
     print("=" * 65)
 
 
-# ── CSV history ───────────────────────────────────────────────────────────────
-
-def _scan_state_csvs(*dirs: Path) -> set[str]:
-    """
-    Scan connector_state_*.csv files in the given directories.
-    Returns the set of connector IDs with status=='created'.
-    """
-    managed: set[str] = set()
-    seen_files: set[Path] = set()
-    for d in dirs:
-        for path in sorted(d.glob("connector_state_*.csv")):
-            if path in seen_files:
-                continue
-            seen_files.add(path)
-            try:
-                with path.open(newline="") as fh:
-                    for row in csv.DictReader(fh):
-                        if row.get("status") == "created" and row.get("connector_id"):
-                            managed.add(row["connector_id"])
-            except Exception as exc:
-                log.warning("Could not read CSV %s: %s", path, exc)
-    log.info("CSV history: %d script-managed connector ID(s) found across %d file(s)",
-             len(managed), len(seen_files))
-    return managed
+def _get_managed_ids(by_id: dict[str, dict]) -> set[str]:
+    """Connector IDs tracked by this script that have not been deleted."""
+    return {cid for cid, row in by_id.items() if row.get("current_status") != "deleted" and cid}
 
 
-def _load_managed_connector_ids(output_dir: Path) -> set[str]:
-    """Collect previously created connector IDs from all known CSV locations."""
-    dirs = {output_dir, Path(".")}
-    return _scan_state_csvs(*dirs)
-
-
-def _load_disabled_connectors(output_dir: Path) -> dict[str, str]:
-    """
-    Read connector_orphans_*.csv files and return {connector_id: subscription_id}
-    for connectors that were disabled by this script (result == 'disabled').
-    """
-    result: dict[str, str] = {}
-    seen: set[Path] = set()
-    for d in {output_dir, Path(".")}:
-        for path in sorted(d.glob("connector_orphans_*.csv")):
-            if path in seen:
-                continue
-            seen.add(path)
-            try:
-                with path.open(newline="") as fh:
-                    for row in csv.DictReader(fh):
-                        if row.get("result") == "disabled" and row.get("connector_id"):
-                            result[row["connector_id"]] = row.get("subscription_id", "")
-            except Exception as exc:
-                log.warning("Could not read orphan CSV %s: %s", path, exc)
-    log.info("Orphan CSV history: %d previously disabled connector(s) found", len(result))
-    return result
+def _get_disabled_map(by_id: dict[str, dict]) -> dict[str, str]:
+    """Return {connector_id: subscription_id} for all disabled connectors."""
+    return {
+        cid: row.get("subscription_id", "")
+        for cid, row in by_id.items()
+        if row.get("current_status") == "disabled"
+    }
 
 
 # ── create ────────────────────────────────────────────────────────────────────
@@ -363,21 +411,20 @@ def cmd_create(args: argparse.Namespace) -> int:
     tenant_id, client_id, client_secret = _azure_creds(cfg)
     root_mg = cfg["azure"].get("rootMg") or None
 
-    app_modules = APP_TYPE_CONFIG.get(qs["app_type_key"], APP_TYPE_CONFIG["CSA"])
-
     log.info("=" * 60)
     log.info("Azure Tenant Connector")
     log.info("Tenant        : %s", tenant_id)
     log.info("SP            : %s", client_id)
     log.info("Qualys        : %s  (%s)", qs["platform_label"], qs["base_url"])
-    log.info("App-type      : %s  →  appInfos=%s", qs["app_type_label"], app_modules)
     log.info("Activation    : %s", qs["activation"] if qs["activation"] else "(none)")
     log.info("Run frequency : %d min", qs["run_frequency"])
     log.info("Gov cloud     : %s", qs["is_gov_cloud"])
     log.info("Scope         : %s", f"MG '{root_mg}' (+ children)" if root_mg else "entire tenant")
     log.info("Orphan check  : %s", qs["disable_orphans"])
     log.info("Connector tags: %s", qs["connector_tags"] or "(none)")
-    log.info("Asset tags    : %s", qs["asset_tags"] or "(none)")
+    log.info("Name prefix   : %s", qs["name_prefix"] or "(none)")
+    log.info("Name suffix   : %s", qs["name_suffix"] or "(none)")
+    log.info("Perimeter scan: %s", qs["perimeter_scan"])
     log.info("Parallel      : %d", parallel)
     log.info("Output dir    : %s", output_dir.resolve())
     log.info("Mode          : %s", "DRY RUN" if dry_run else "LIVE")
@@ -402,7 +449,7 @@ def cmd_create(args: argparse.Namespace) -> int:
     print("  " + "-" * 105)
     for idx, sub in enumerate(subscriptions, 1):
         sub_id = sub["subscriptionId"]
-        name   = resolve_connector_name(sub.get("displayName"), sub_id)
+        name   = resolve_connector_name(sub.get("displayName"), sub_id, qs["name_prefix"], qs["name_suffix"])
         mg     = sub.get("managementGroupName", "")
         print(f"  {idx:<4} {sub_id:<38} {name:<42} {mg}")
     print()
@@ -412,7 +459,7 @@ def cmd_create(args: argparse.Namespace) -> int:
             ConnectorResult(
                 subscription_id=sub["subscriptionId"],
                 subscription_name=sub.get("displayName", sub["subscriptionId"]),
-                connector_name=resolve_connector_name(sub.get("displayName"), sub["subscriptionId"]),
+                connector_name=resolve_connector_name(sub.get("displayName"), sub["subscriptionId"], qs["name_prefix"], qs["name_suffix"]),
                 management_group=sub.get("managementGroupName", ""),
                 success=True,
                 status="dry_run",
@@ -420,22 +467,29 @@ def cmd_create(args: argparse.Namespace) -> int:
             for sub in subscriptions
         ]
         _print_summary(results)
-        csv_path = _save_csv(results, tenant_id, qs["app_type_label"], dry_run=True, output_dir=output_dir)
-        log.info("DRY RUN — CSV saved: %s", csv_path)
+        csv_path = _upsert_create_results(results, tenant_id, qs["platform_label"],
+                                          dry_run=True, output_dir=output_dir)
+        log.info("DRY RUN — CSV updated: %s", csv_path)
         return 0
 
     client = _qualys_client(qs)
 
+    log.info("Verifying Qualys credentials and Connectors module access …")
+    ok, reason = client.verify_access()
+    if not ok:
+        log.error("Qualys access check failed: %s", reason)
+        return 1
+    log.info("Qualys access check passed.")
+
     connector_tag_ids: list[int] = []
-    asset_tag_ids: list[int] = []
     if qs["connector_tags"]:
         connector_tag_ids = client.resolve_tag_names(qs["connector_tags"])
-    if qs["asset_tags"]:
-        asset_tag_ids = client.resolve_tag_names(qs["asset_tags"])
 
     # Drift detection — scoped strictly to connectors this script previously created
+    orphan_updates: list[tuple[str, str, str, str]] = []  # (id, action, status, note)
     if qs["disable_orphans"]:
-        managed_ids = _load_managed_connector_ids(output_dir)
+        by_sub_pre, by_id_pre = _load_connector_csv(output_dir)
+        managed_ids = _get_managed_ids(by_id_pre)
         if not managed_ids:
             log.warning(
                 "Orphan detection requested (disableOrphans=true) but no CSV history found. "
@@ -447,14 +501,16 @@ def cmd_create(args: argparse.Namespace) -> int:
             log.info("Drift check — disabling script-managed connectors for subscriptions no longer in scope …")
             orphans = client.disable_orphan_connectors(active_sub_ids, managed_connector_ids=managed_ids)
             if orphans:
-                orphan_csv = _save_orphan_csv(orphans, output_dir)
                 dis  = sum(1 for o in orphans if o["result"] == "disabled")
                 fail = len(orphans) - dis
-                log.info("Orphans: %d disabled, %d failed  →  %s", dis, fail, orphan_csv)
+                log.info("Orphans: %d disabled, %d failed", dis, fail)
                 print("\n  Orphan connectors (subscription no longer active):")
                 for o in orphans:
-                    icon = "✓" if o["result"] == "disabled" else "✗"
+                    icon   = "✓" if o["result"] == "disabled" else "✗"
+                    action = "orphan_disable" if o["result"] == "disabled" else "orphan_disable_failed"
+                    status = "disabled"       if o["result"] == "disabled" else "active"
                     print(f"    {icon} [{o['id']}] {o['name']} (sub={o['subscriptionId']}) — {o['result']}")
+                    orphan_updates.append((o["id"], action, status, o.get("note", "")))
 
     results = client.create_connectors_bulk(
         subscriptions=subscriptions,
@@ -462,12 +518,15 @@ def cmd_create(args: argparse.Namespace) -> int:
         application_id=client_id,
         authentication_key=client_secret,
         is_gov_cloud=qs["is_gov_cloud"],
-        app_type=qs["app_type_key"],
         activation_modules=qs["activation"],
         run_frequency=qs["run_frequency"],
         connector_tag_ids=connector_tag_ids,
-        asset_tag_ids=asset_tag_ids,
         parallel=parallel,
+        name_prefix=qs["name_prefix"],
+        name_suffix=qs["name_suffix"],
+        perimeter_scan=qs["perimeter_scan"],
+        scan_config=qs["scan_config"],
+        app_modules=qs["app_modules"],
     )
 
     _print_summary(results)
@@ -486,9 +545,15 @@ def cmd_create(args: argparse.Namespace) -> int:
                          st.get("last_synced_on", "?"),
                          st.get("total_assets_created", "?"))
 
-    csv_path = _save_csv(results, tenant_id, qs["app_type_label"], dry_run=False,
-                         output_dir=output_dir, states=states)
-    log.info("State CSV saved: %s", csv_path)
+    csv_path = _upsert_create_results(results, tenant_id, qs["platform_label"],
+                                      dry_run=False, output_dir=output_dir, states=states)
+    # Apply any orphan disable updates into the same file
+    if orphan_updates:
+        by_sub, by_id = _load_connector_csv(output_dir)
+        for cid, action, status, note in orphan_updates:
+            _apply_action(cid, action, status, note, by_sub, by_id)
+        _write_connector_csv(by_sub, by_id, output_dir)
+    log.info("CSV updated: %s", csv_path)
     return 1 if any(r.status == "failed" for r in results) else 0
 
 
@@ -609,31 +674,197 @@ def cmd_delete(args: argparse.Namespace) -> int:
     client = _qualys_client(qs)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    ids    = args.ids
+
+    if args.all:
+        _, by_id = _load_connector_csv(output_dir)
+        managed_ids = _get_managed_ids(by_id)
+        if not managed_ids:
+            log.error(
+                "No connector IDs found in %s. "
+                "Run 'create' first so the script has a record of what it created.",
+                output_dir / _CSV_FILE,
+            )
+            return 1
+        ids = sorted(managed_ids)
+        log.info("--all: %d script-managed connector(s) found in CSV history", len(ids))
+        print(f"\n  Found {len(ids)} script-managed connector(s) in CSV history:")
+        for cid in ids:
+            print(f"    {cid}")
+        confirm = input("\n  Delete all of the above? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("  Aborted.")
+            return 0
+    elif args.ids:
+        ids = args.ids
+    else:
+        log.error("Provide --ids <ID ...> or --all")
+        return 1
+
     total  = len(ids)
     failed = 0
 
     log.info("Qualys platform: %s  (%s)", qs["platform_label"], qs["base_url"])
     print(f"\n  Deleting {total} connector(s) …\n")
-    rows = []
+    by_sub, by_id = _load_connector_csv(output_dir)
     for cid in ids:
         ok, msg = _delete_one(client, cid)
         icon = "✓" if ok else "✗"
         print(f"  {icon}  [{cid}]  {msg}")
-        rows.append({"connector_id": cid, "status": "deleted" if ok else "failed", "note": msg})
+        _apply_action(cid, "deleted" if ok else "delete_failed", "deleted" if ok else "active",
+                      msg, by_sub, by_id)
         if not ok:
             failed += 1
 
-    filename = output_dir / f"connector_delete_{_ts()}.csv"
-    with open(filename, "w", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=["timestamp", "connector_id", "status", "note"])
-        writer.writeheader()
-        now = datetime.now(timezone.utc).isoformat()
-        for row in rows:
-            writer.writerow({"timestamp": now, **row})
-
+    csv_path = _write_connector_csv(by_sub, by_id, output_dir)
     print(f"\n  Summary: {total - failed} deleted, {failed} failed")
-    log.info("Delete log saved: %s", filename)
+    log.info("CSV updated: %s", csv_path)
+    return 1 if failed else 0
+
+
+# ── update ────────────────────────────────────────────────────────────────────
+
+def cmd_update(args: argparse.Namespace) -> int:
+    cfg = load_config(args.config)
+    qs  = _qualys_settings(cfg)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    by_sub, by_id = _load_connector_csv(output_dir)
+
+    if args.all:
+        managed_ids = _get_managed_ids(by_id)
+        if not managed_ids:
+            log.error(
+                "No connector IDs found in %s. "
+                "Run 'create' first so the script has a record of what it created.",
+                output_dir / _CSV_FILE,
+            )
+            return 1
+        ids = sorted(managed_ids)
+        print(f"\n  Found {len(ids)} script-managed connector(s) in CSV history:")
+        for cid in ids:
+            row = by_id.get(cid, {})
+            print(f"    {cid}  ({row.get('subscription_name', '')})")
+        confirm = input("\n  Update all of the above? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("  Aborted.")
+            return 0
+    elif args.ids:
+        ids = args.ids
+    else:
+        log.error("Provide --ids <ID ...> or --all")
+        return 1
+
+    tenant_id, client_id, client_secret = _azure_creds(cfg)
+    client = _qualys_client(qs)
+
+    connector_tag_ids: list[int] = []
+    if qs["connector_tags"]:
+        connector_tag_ids = client.resolve_tag_names(qs["connector_tags"])
+
+    total  = len(ids)
+    failed = 0
+
+    log.info("Qualys platform: %s  (%s)", qs["platform_label"], qs["base_url"])
+    log.info("Updating %d connector(s) …", total)
+    print(f"\n  Updating {total} connector(s) …\n")
+
+    for cid in ids:
+        row    = by_id.get(cid, {})
+        sub_id = row.get("subscription_id", "")
+        disp   = row.get("subscription_name", "")
+        mg     = row.get("management_group", "")
+
+        if not sub_id:
+            log.warning("  [%s] subscription_id not in CSV — skipping", cid)
+            print(f"  ⚠  [{cid}]  subscription_id not in CSV, skipping")
+            failed += 1
+            continue
+
+        conn_name = resolve_connector_name(disp, sub_id, qs["name_prefix"], qs["name_suffix"])
+        result = client.update_connector(
+            connector_id=cid,
+            connector_name=conn_name,
+            subscription_id=sub_id,
+            subscription_name=disp or sub_id,
+            management_group=mg,
+            directory_id=tenant_id,
+            application_id=client_id,
+            authentication_key=client_secret,
+            is_gov_cloud=qs["is_gov_cloud"],
+            activation_modules=qs["activation"],
+            run_frequency=qs["run_frequency"],
+            connector_tag_ids=connector_tag_ids,
+            perimeter_scan=qs["perimeter_scan"],
+            scan_config=qs["scan_config"],
+            app_modules=qs["app_modules"],
+        )
+        icon = "✓" if result.success else "✗"
+        note = f"  — {result.note}" if result.note else ""
+        print(f"  {icon}  [{cid}]  {conn_name}{note}")
+        _apply_action(cid, result.status, "active" if result.success else "failed",
+                      result.note or "", by_sub, by_id)
+        if not result.success:
+            failed += 1
+
+    csv_path = _write_connector_csv(by_sub, by_id, output_dir)
+    print(f"\n  Summary: {total - failed} updated, {failed} failed")
+    log.info("CSV updated: %s", csv_path)
+    return 1 if failed else 0
+
+
+# ── disable ───────────────────────────────────────────────────────────────────
+
+def cmd_disable(args: argparse.Namespace) -> int:
+    cfg    = load_config(args.config)
+    qs     = _qualys_settings(cfg)
+    client = _qualys_client(qs)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.all:
+        _, by_id = _load_connector_csv(output_dir)
+        managed_ids = _get_managed_ids(by_id)
+        if not managed_ids:
+            log.error(
+                "No connector IDs found in %s. "
+                "Run 'create' first so the script has a record of what it created.",
+                output_dir / _CSV_FILE,
+            )
+            return 1
+        ids = sorted(managed_ids)
+        log.info("--all: %d script-managed connector(s) found in CSV history", len(ids))
+        print(f"\n  Found {len(ids)} script-managed connector(s) in CSV history:")
+        for cid in ids:
+            print(f"    {cid}")
+        confirm = input("\n  Disable all of the above? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("  Aborted.")
+            return 0
+    elif args.ids:
+        ids = args.ids
+    else:
+        log.error("Provide --ids <ID ...> or --all")
+        return 1
+
+    total  = len(ids)
+    failed = 0
+
+    log.info("Qualys platform: %s  (%s)", qs["platform_label"], qs["base_url"])
+    print(f"\n  Disabling {total} connector(s) …\n")
+    by_sub, by_id = _load_connector_csv(output_dir)
+    for cid in ids:
+        ok, msg = client.disable_connector(cid)
+        icon = "✓" if ok else "✗"
+        print(f"  {icon}  [{cid}]  {msg}")
+        _apply_action(cid, "disabled" if ok else "disable_failed", "disabled" if ok else "active",
+                      msg, by_sub, by_id)
+        if not ok:
+            failed += 1
+
+    csv_path = _write_connector_csv(by_sub, by_id, output_dir)
+    print(f"\n  Summary: {total - failed} disabled, {failed} failed")
+    log.info("CSV updated: %s", csv_path)
     return 1 if failed else 0
 
 
@@ -641,15 +872,16 @@ def cmd_delete(args: argparse.Namespace) -> int:
 
 def cmd_restore_orphans(args: argparse.Namespace) -> int:
     """
-    Re-enable connectors that were previously disabled by this script (tracked in
-    connector_orphans_*.csv) if their Azure subscription is now active again.
+    Re-enable connectors that were previously disabled by this script if their
+    Azure subscription is now active again.
     """
     cfg = load_config(args.config)
     qs  = _qualys_settings(cfg)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    disabled = _load_disabled_connectors(output_dir)
+    by_sub, by_id = _load_connector_csv(output_dir)
+    disabled = _get_disabled_map(by_id)
     if not disabled:
         log.info("No previously disabled connectors found in CSV history — nothing to restore.")
         return 0
@@ -676,38 +908,37 @@ def cmd_restore_orphans(args: argparse.Namespace) -> int:
     log.info("Restoring %d connector(s) whose subscriptions are now active …", len(to_restore))
     client = _qualys_client(qs)
     print(f"\n  Restoring {len(to_restore)} connector(s) …\n")
-    rows = []
     failed = 0
     for cid, sub_id in to_restore.items():
         ok, msg = client.enable_connector(cid)
         icon = "✓" if ok else "✗"
         print(f"  {icon}  [{cid}]  sub={sub_id}  {msg}")
-        rows.append({"connector_id": cid, "subscription_id": sub_id,
-                     "result": "enabled" if ok else "failed", "note": msg})
+        _apply_action(cid, "enabled" if ok else "enable_failed", "active" if ok else "disabled",
+                      msg, by_sub, by_id)
         if not ok:
             failed += 1
 
-    filename = output_dir / f"connector_restore_{_ts()}.csv"
-    with open(filename, "w", newline="") as fh:
-        writer = csv.DictWriter(
-            fh, fieldnames=["timestamp", "connector_id", "subscription_id", "result", "note"])
-        writer.writeheader()
-        now = datetime.now(timezone.utc).isoformat()
-        for row in rows:
-            writer.writerow({"timestamp": now, **row})
-
+    csv_path = _write_connector_csv(by_sub, by_id, output_dir)
     ok_count = len(to_restore) - failed
     print(f"\n  Summary: {ok_count} enabled, {failed} failed")
-    log.info("Restore log saved: %s", filename)
+    log.info("CSV updated: %s", csv_path)
     return 1 if failed else 0
 
 
 # ── CLI wiring ────────────────────────────────────────────────────────────────
 
 def main():
+    # Shared parent parser so --verbose/-v works after the subcommand too
+    _common = argparse.ArgumentParser(add_help=False)
+    _common.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Enable DEBUG logging (shows request/response XML)",
+    )
+
     parser = argparse.ArgumentParser(
         description="Azure → Qualys tenant connector  (all settings in config.json)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[_common],
     )
     parser.add_argument(
         "--config", default="config.json", metavar="FILE",
@@ -720,39 +951,63 @@ def main():
     sub = parser.add_subparsers(dest="command", required=True)
 
     # create
-    p_create = sub.add_parser("create", help="Discover subscriptions and create connectors")
+    p_create = sub.add_parser("create", help="Discover subscriptions and create connectors",
+                              parents=[_common])
     p_create.add_argument("--dry-run", action="store_true",
                           help="Enumerate Azure subscriptions only; skip all Qualys API calls")
     p_create.add_argument("--parallel", type=int, default=1, metavar="N",
                           help="Number of concurrent connector creation threads (default: 1)")
 
     # list
-    p_list = sub.add_parser("list", help="List all Azure connectors in Qualys")
+    p_list = sub.add_parser("list", help="List all Azure connectors in Qualys",
+                            parents=[_common])
     p_list.add_argument("--subscription", metavar="ID",
                         help="Filter by subscription ID (substring match)")
 
     # status
-    p_status = sub.add_parser("status", help="Show live state for one or more connector IDs")
+    p_status = sub.add_parser("status", help="Show live state for one or more connector IDs",
+                              parents=[_common])
     p_status.add_argument("--ids", metavar="ID", nargs="+", required=True,
                           help="One or more Qualys connector IDs")
 
     # list-mgs
-    sub.add_parser("list-mgs", help="Print MG hierarchy — use to pick azure.rootMg in config")
+    sub.add_parser("list-mgs", help="Print MG hierarchy — use to pick azure.rootMg in config",
+                   parents=[_common])
 
     # delete
-    p_delete = sub.add_parser("delete", help="Delete one or more connectors by Qualys ID")
-    p_delete.add_argument("--ids", metavar="ID", nargs="+", required=True,
+    p_delete = sub.add_parser("delete", help="Delete one or more connectors by Qualys ID",
+                              parents=[_common])
+    p_delete.add_argument("--ids", metavar="ID", nargs="+",
                           help="One or more Qualys connector IDs to delete")
+    p_delete.add_argument("--all", action="store_true",
+                          help="Delete all connectors previously created by this script (reads CSV history)")
+
+    # update
+    p_update = sub.add_parser("update", help="Update existing connectors (name, auth key, activation, frequency)",
+                              parents=[_common])
+    p_update.add_argument("--ids", metavar="ID", nargs="+",
+                          help="One or more Qualys connector IDs to update")
+    p_update.add_argument("--all", action="store_true",
+                          help="Update all connectors previously created by this script (reads CSV history)")
+
+    # disable
+    p_disable = sub.add_parser("disable", help="Disable one or more connectors by Qualys ID",
+                               parents=[_common])
+    p_disable.add_argument("--ids", metavar="ID", nargs="+",
+                           help="One or more Qualys connector IDs to disable")
+    p_disable.add_argument("--all", action="store_true",
+                           help="Disable all connectors previously created by this script (reads CSV history)")
 
     # restore-orphans
     sub.add_parser("restore-orphans",
-                   help="Re-enable previously disabled connectors whose subscriptions are now active")
+                   help="Re-enable previously disabled connectors whose subscriptions are now active",
+                   parents=[_common])
 
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    log_path = _setup_logging(output_dir)
+    log_path = _setup_logging(output_dir, verbose=args.verbose)
     log.info("Log file: %s", log_path)
 
     dispatch = {
@@ -761,6 +1016,8 @@ def main():
         "status":          cmd_status,
         "list-mgs":        cmd_list_mgs,
         "delete":          cmd_delete,
+        "update":          cmd_update,
+        "disable":         cmd_disable,
         "restore-orphans": cmd_restore_orphans,
     }
     sys.exit(dispatch[args.command](args))

--- a/Connectors/Azure/TenantConnector/main.py
+++ b/Connectors/Azure/TenantConnector/main.py
@@ -181,11 +181,51 @@ def _qualys_settings(cfg: dict) -> dict:
         sys.exit(1)
 
     if perimeter_scan and scan_config:
-        valid_days = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}
-        bad_days   = [d for d in (scan_config.get("daysOfWeek") or []) if d not in valid_days]
+        _VALID_DAYS       = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}
+        _VALID_RECURRENCE = {"WEEKLY", "MONTHLY"}
+
+        # optionProfileId — required positive integer
+        opid = scan_config.get("optionProfileId")
+        if not opid or not isinstance(opid, int) or opid <= 0:
+            log.error("perimeterScanConfig.optionProfileId must be a positive integer (got %r).", opid)
+            sys.exit(1)
+
+        # recurrence
+        recurrence = (scan_config.get("recurrence") or "").upper()
+        if recurrence not in _VALID_RECURRENCE:
+            log.error(
+                "perimeterScanConfig.recurrence=%r is invalid. Allowed: %s",
+                recurrence, sorted(_VALID_RECURRENCE),
+            )
+            sys.exit(1)
+
+        # daysOfWeek — required for WEEKLY
+        days = scan_config.get("daysOfWeek") or []
+        bad_days = [d for d in days if d not in _VALID_DAYS]
         if bad_days:
             log.error("perimeterScanConfig.daysOfWeek contains invalid values: %s  (valid: %s)",
-                      bad_days, sorted(valid_days))
+                      bad_days, sorted(_VALID_DAYS))
+            sys.exit(1)
+        if recurrence == "WEEKLY" and not days:
+            log.error("perimeterScanConfig.daysOfWeek is required when recurrence=WEEKLY.")
+            sys.exit(1)
+
+        # startDate — required, MM/DD/YYYY
+        import re as _re
+        start_date = scan_config.get("startDate") or ""
+        if not _re.fullmatch(r"\d{2}/\d{2}/\d{4}", start_date):
+            log.error("perimeterScanConfig.startDate=%r must be in MM/DD/YYYY format.", start_date)
+            sys.exit(1)
+
+        # startTime — required, HH:MM
+        start_time = scan_config.get("startTime") or ""
+        if not _re.fullmatch(r"\d{2}:\d{2}", start_time):
+            log.error("perimeterScanConfig.startTime=%r must be in HH:MM format.", start_time)
+            sys.exit(1)
+
+        # timezone — required
+        if not (scan_config.get("timezone") or "").strip():
+            log.error("perimeterScanConfig.timezone is required.")
             sys.exit(1)
 
     return {

--- a/Connectors/Azure/TenantConnector/main.py
+++ b/Connectors/Azure/TenantConnector/main.py
@@ -163,21 +163,18 @@ def _qualys_settings(cfg: dict) -> dict:
     perimeter_scan = bool(q.get("perimeterScan", False))
     scan_config    = q.get("perimeterScanConfig") or None
 
-    _VALID_APP_MODULES = {"AI", "CI", "CSA"}
-    raw_app_modules = q.get("appModules") or []
-    app_modules = [m.upper() for m in raw_app_modules]
-    bad_mods = [m for m in app_modules if m not in _VALID_APP_MODULES]
-    if bad_mods:
-        log.error("Config qualys.appModules contains invalid values: %s  (valid: AI, CI, CSA)", bad_mods)
+    _APP_TYPE_MAP = {
+        "asset-inventory": ["AI"],
+        "cspm":            ["AI", "CI", "CSA"],
+    }
+    raw_app_type = (q.get("appType") or "").strip().lower()
+    if raw_app_type not in _APP_TYPE_MAP:
+        log.error(
+            "Config qualys.appType=%r is invalid. Allowed values: %s",
+            raw_app_type, list(_APP_TYPE_MAP),
+        )
         sys.exit(1)
-
-    # CSA and CI both require the full AI+CI+CSA bundle
-    if ("CSA" in app_modules or "CI" in app_modules):
-        if not {"AI", "CI", "CSA"}.issubset(set(app_modules)):
-            log.error(
-                "Config qualys.appModules: CI and CSA must always be enabled together with AI (use [\"AI\",\"CI\",\"CSA\"])."
-            )
-            sys.exit(1)
+    app_modules = _APP_TYPE_MAP[raw_app_type]
 
     if perimeter_scan and "VM" not in activation:
         log.error("Config: perimeterScan=true requires \"VM\" in qualys.activation.")

--- a/Connectors/Azure/TenantConnector/qualys_client.py
+++ b/Connectors/Azure/TenantConnector/qualys_client.py
@@ -57,17 +57,12 @@ def resolve_platform_url(platform_or_url: str) -> str:
     )
 
 _CREATE_PATH      = "/qps/rest/3.0/create/am/azureassetdataconnector"
+_DELETE_PATH      = "/qps/rest/3.0/delete/am/azureassetdataconnector"
 _SEARCH_PATH      = "/qps/rest/3.0/search/am/azureassetdataconnector"
 _UPDATE_PATH      = "/qps/rest/3.0/update/am/azureassetdataconnector"
 _TAG_SEARCH_PATH  = "/qps/rest/2.0/search/am/tag"
 _TAG_CREATE_PATH  = "/qps/rest/2.0/create/am/tag"
 _DEFAULT_RUN_FREQUENCY = 1440  # minutes (24 hours)
-
-# App-type → connectorAppInfos modules; activation is controlled separately
-APP_TYPE_CONFIG: dict[str, list[str]] = {
-    "AI":  ["AI"],
-    "CSA": ["AI", "CI", "CSA"],
-}
 
 VALID_ACTIVATION_MODULES = ["VM", "CERTVIEW", "SCA", "PC"]
 
@@ -75,10 +70,16 @@ VALID_ACTIVATION_MODULES = ["VM", "CERTVIEW", "SCA", "PC"]
 _MAX_NAME_LEN = 255
 
 
-def resolve_connector_name(display_name: Optional[str], subscription_id: str) -> str:
-    """Use the subscription alias if present, else azure-sub-<id>. Caps at 255 chars."""
+def resolve_connector_name(
+    display_name: Optional[str],
+    subscription_id: str,
+    prefix: str = "",
+    suffix: str = "",
+) -> str:
+    """Build connector name: {prefix}{subscription_name}{suffix}, capped at 255 chars."""
     alias = (display_name or "").strip()
-    name = alias if alias else f"azure-sub-{subscription_id}"
+    base  = alias if alias else f"azure-sub-{subscription_id}"
+    name  = f"{prefix}{base}{suffix}"
     return name[:_MAX_NAME_LEN]
 
 
@@ -104,6 +105,64 @@ def _xe(value: str) -> str:
     )
 
 
+def _build_scan_config_xml(scan_cfg: dict) -> str:
+    """Build connectorScanSetting + connectorScanConfig XML blocks."""
+    days_xml = "\n".join(
+        f"                            <Day>{d}</Day>"
+        for d in (scan_cfg.get("daysOfWeek") or [])
+    )
+    days_block = f"""
+                        <daysOfWeek>
+                            <set>
+{days_xml}
+                            </set>
+                        </daysOfWeek>""" if days_xml else ""
+
+    return f"""
+            <connectorScanSetting>
+                <isCustomScanConfigEnabled>true</isCustomScanConfigEnabled>
+            </connectorScanSetting>
+            <connectorScanConfig>
+                <set>
+                    <ConnectorScanConfiguration>{days_block}
+                        <optionProfileId>{scan_cfg.get("optionProfileId", "")}</optionProfileId>
+                        <recurrence>{scan_cfg.get("recurrence", "WEEKLY")}</recurrence>
+                        <scanPrefix>{_xe(scan_cfg.get("scanPrefix", ""))}</scanPrefix>
+                        <startDate>{scan_cfg.get("startDate", "")}</startDate>
+                        <startTime>{scan_cfg.get("startTime", "")}</startTime>
+                        <timezone>{scan_cfg.get("timezone", "UTC")}</timezone>
+                    </ConnectorScanConfiguration>
+                </set>
+            </connectorScanConfig>"""
+
+
+def _build_app_infos_xml(app_modules: list[str], subscription_id: str, tag_id: Optional[int] = None) -> str:
+    """
+    Build <connectorAppInfos> block using the correct ConnectorAppInfoQList structure.
+    Valid app module names: AI (Asset Inventory), CI (Cloud Inventory), CSA (Cloud Security Assessment).
+    Each module gets its own <ConnectorAppInfoQList> wrapper per the API spec.
+    """
+    if not app_modules:
+        return ""
+    lists_xml = ""
+    for module in app_modules:
+        tag_xml = f"\n                            <tagId>{tag_id}</tagId>" if tag_id else ""
+        lists_xml += f"""
+                    <ConnectorAppInfoQList>
+                        <set>
+                            <ConnectorAppInfo>
+                                <name>{module}</name>
+                                <identifier>{_xe(subscription_id)}</identifier>{tag_xml}
+                            </ConnectorAppInfo>
+                        </set>
+                    </ConnectorAppInfoQList>"""
+    return f"""
+            <connectorAppInfos>
+                <set>{lists_xml}
+                </set>
+            </connectorAppInfos>"""
+
+
 def _build_create_xml(
     name: str,
     description: str,
@@ -112,18 +171,28 @@ def _build_create_xml(
     application_id: str,
     authentication_key: str,
     is_gov_cloud: bool,
-    app_modules: list[str],
     activation_modules: list[str],
     run_frequency: int,
     connector_tag_ids: list[int],
-    asset_tag_ids: list[int],
+    perimeter_scan: bool = False,
+    scan_config: Optional[dict] = None,
+    app_modules: Optional[list[str]] = None,
 ) -> str:
     act_items = "\n".join(
         f"                    <ActivationModule>{m}</ActivationModule>"
         for m in activation_modules
     )
+    activation_xml = ""
+    if act_items:
+        activation_xml = f"""
+            <activation>
+                <set>
+{act_items}
+                </set>
+            </activation>"""
 
     tags_xml = ""
+    first_tag_id = connector_tag_ids[0] if connector_tag_ids else None
     if connector_tag_ids:
         tag_items = "\n".join(
             f"                    <TagSimple><id>{tid}</id></TagSimple>"
@@ -136,65 +205,74 @@ def _build_create_xml(
                 </set>
             </defaultTags>"""
 
-    def _app_list(app_name: str) -> str:
-        if asset_tag_ids:
-            entries = "\n".join(
-                f"""                            <ConnectorAppInfo>
-                                <name>{app_name}</name>
-                                <identifier>{_xe(subscription_id)}</identifier>
-                                <tagId>{tid}</tagId>
-                            </ConnectorAppInfo>"""
-                for tid in asset_tag_ids
-            )
-        else:
-            entries = f"""                            <ConnectorAppInfo>
-                                <name>{app_name}</name>
-                                <identifier>{_xe(subscription_id)}</identifier>
-                            </ConnectorAppInfo>"""
-        return f"""                    <ConnectorAppInfoQList>
-                        <set>
-{entries}
-                        </set>
-                    </ConnectorAppInfoQList>"""
+    # connectorAppInfos: present when app_modules specified (AI/CI/CSA)
+    # Per API docs, each module needs its own ConnectorAppInfoQList wrapper
+    app_infos_xml = _build_app_infos_xml(app_modules or [], subscription_id, tag_id=first_tag_id)
 
-    app_lists = "\n".join(_app_list(m) for m in app_modules)
+    # isCPSEnabled only included when enabling CPS (never send false)
+    cps_xml = "\n            <isCPSEnabled>true</isCPSEnabled>" if perimeter_scan else ""
+
+    # When CPS is enabled, connectorScanSetting is always required.
+    # If no custom scan_config is provided, use the global scan configuration.
+    scan_xml = ""
+    if perimeter_scan:
+        if scan_config:
+            scan_xml = _build_scan_config_xml(scan_config)
+        else:
+            scan_xml = """
+            <connectorScanSetting>
+                <isCustomScanConfigEnabled>false</isCustomScanConfigEnabled>
+            </connectorScanSetting>"""
 
     return f"""<?xml version="1.0" encoding="UTF-8" ?>
 <ServiceRequest>
     <data>
         <AzureAssetDataConnector>
             <name>{_xe(name)}</name>
-            <description>{_xe(description)}</description>{tags_xml}
-            <activation>
-                <set>
-{act_items}
-                </set>
-            </activation>
+            <description>{_xe(description)}</description>{tags_xml}{activation_xml}
             <disabled>false</disabled>
             <runFrequency>{run_frequency}</runFrequency>
-            <isRemediationEnabled>false</isRemediationEnabled>
+            <isRemediationEnabled>false</isRemediationEnabled>{cps_xml}
             <isGovCloudConfigured>{"true" if is_gov_cloud else "false"}</isGovCloudConfigured>
             <authRecord>
                 <applicationId>{_xe(application_id)}</applicationId>
                 <directoryId>{_xe(directory_id)}</directoryId>
                 <subscriptionId>{_xe(subscription_id)}</subscriptionId>
                 <authenticationKey>{_xe(authentication_key)}</authenticationKey>
-            </authRecord>
-            <connectorAppInfos>
-                <set>
-{app_lists}
-                </set>
-            </connectorAppInfos>
+            </authRecord>{app_infos_xml}{scan_xml}
         </AzureAssetDataConnector>
     </data>
 </ServiceRequest>"""
 
 
-def _parse_response(xml_text: str) -> tuple[bool, Optional[str], Optional[str]]:
+_PERMISSION_CODES = frozenset({
+    "UNAUTHORIZED", "FORBIDDEN", "INVALID_CREDENTIALS", "NOT_AUTHORIZED",
+})
+
+_PERMISSION_GUIDANCE = (
+    "Check: (1) Qualys username/password in config, "
+    "(2) platform key matches your Qualys account region, "
+    "(3) your Qualys account has the Connectors module licensed."
+)
+
+
+def _classify_http_error(status_code: int) -> Optional[str]:
+    if status_code == 401:
+        return f"HTTP 401 Unauthorized — invalid Qualys credentials. {_PERMISSION_GUIDANCE}"
+    if status_code == 403:
+        return f"HTTP 403 Forbidden — Connectors module not licensed or IP not allowed. {_PERMISSION_GUIDANCE}"
+    return None
+
+
+def _parse_response(resp: "requests.Response") -> tuple[bool, Optional[str], Optional[str]]:
+    http_err = _classify_http_error(resp.status_code)
+    if http_err:
+        return False, None, http_err
+
     try:
-        root = ET.fromstring(xml_text)
+        root = ET.fromstring(resp.text)
     except ET.ParseError as exc:
-        return False, None, f"XML parse error: {exc}"
+        return False, None, f"XML parse error (HTTP {resp.status_code}): {exc}"
 
     code = root.findtext("responseCode", "")
     if code == "SUCCESS":
@@ -205,6 +283,10 @@ def _parse_response(xml_text: str) -> tuple[bool, Optional[str], Optional[str]]:
         or root.findtext("responseMessage")
         or "Unknown error"
     )
+
+    if code in _PERMISSION_CODES:
+        return False, None, f"{code}: {err}. {_PERMISSION_GUIDANCE}"
+
     return False, None, f"{code}: {err}"
 
 
@@ -286,6 +368,44 @@ class QualysClient:
 
         return all_items
 
+    def verify_access(self) -> tuple[bool, str]:
+        """
+        Lightweight pre-flight check: validates credentials and Connectors module access.
+        Returns (ok, reason). On failure, reason is an actionable message.
+        """
+        body = """<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+    <preferences>
+        <limitResults>1</limitResults>
+    </preferences>
+</ServiceRequest>"""
+        try:
+            resp = self._post(_SEARCH_PATH, body, retries=1)
+        except requests.RequestException as exc:
+            return False, f"Could not reach Qualys API at {self._base}: {exc}. Check platform key and network."
+
+        http_err = _classify_http_error(resp.status_code)
+        if http_err:
+            return False, http_err
+
+        try:
+            root = ET.fromstring(resp.text)
+        except ET.ParseError as exc:
+            return False, f"Unexpected response from Qualys (HTTP {resp.status_code}): {exc}"
+
+        code = root.findtext("responseCode", "")
+        if code == "SUCCESS":
+            return True, "OK"
+
+        err = (
+            root.findtext("responseErrorDetails/errorMessage")
+            or root.findtext("responseMessage")
+            or "Unknown error"
+        )
+        if code in _PERMISSION_CODES:
+            return False, f"{code}: {err}. {_PERMISSION_GUIDANCE}"
+        return False, f"{code}: {err}"
+
     def connector_exists(self, subscription_id: str) -> Optional[str]:
         log.debug("Checking if connector exists for subscription %s", subscription_id)
         body = f"""<?xml version="1.0" encoding="UTF-8" ?>
@@ -318,18 +438,18 @@ class QualysClient:
         authentication_key: str,
         description: str = "",
         is_gov_cloud: bool = True,
-        app_type: str = "CSA",
         activation_modules: Optional[list[str]] = None,
         run_frequency: int = _DEFAULT_RUN_FREQUENCY,
         connector_tag_ids: Optional[list[int]] = None,
-        asset_tag_ids: Optional[list[int]] = None,
         skip_if_exists: bool = True,
+        perimeter_scan: bool = False,
+        scan_config: Optional[dict] = None,
+        app_modules: Optional[list[str]] = None,
     ) -> ConnectorResult:
-        app_modules = APP_TYPE_CONFIG.get(app_type.upper(), APP_TYPE_CONFIG["CSA"])
-        activation_modules = activation_modules or []
+        activation_modules = list(activation_modules or [])
         log.debug(
-            "Connector params — app_type=%s app_modules=%s activation=%s gov=%s freq=%d",
-            app_type, app_modules, activation_modules, is_gov_cloud, run_frequency,
+            "Connector params — activation=%s app_modules=%s gov=%s freq=%d perimeter_scan=%s",
+            activation_modules, app_modules, is_gov_cloud, run_frequency, perimeter_scan,
         )
 
         base_result = dict(
@@ -356,21 +476,23 @@ class QualysClient:
             application_id=application_id,
             authentication_key=authentication_key,
             is_gov_cloud=is_gov_cloud,
-            app_modules=app_modules,
             activation_modules=activation_modules,
             run_frequency=run_frequency,
             connector_tag_ids=connector_tag_ids or [],
-            asset_tag_ids=asset_tag_ids or [],
+            perimeter_scan=perimeter_scan,
+            scan_config=scan_config,
+            app_modules=app_modules,
         )
 
         log.info("Creating connector '%s' (%s)", connector_name, subscription_id)
+        log.debug("Request XML:\n%s", body)
         try:
             resp = self._post(_CREATE_PATH, body)
         except requests.RequestException as exc:
             return ConnectorResult(**base_result, success=False, status="failed", note=str(exc))
 
-        log.debug("Response %d: %s", resp.status_code, resp.text[:400])
-        success, cid, error = _parse_response(resp.text)
+        log.debug("Response %d: %s", resp.status_code, resp.text)
+        success, cid, error = _parse_response(resp)
 
         if success:
             log.info("  ✓ id=%s", cid)
@@ -384,6 +506,88 @@ class QualysClient:
             status="created" if success else "failed",
             note=error if not success else None,
         )
+
+    def update_connector(
+        self,
+        connector_id: str,
+        connector_name: str,
+        subscription_id: str,
+        subscription_name: str,
+        management_group: str,
+        directory_id: str,
+        application_id: str,
+        authentication_key: str,
+        is_gov_cloud: bool = True,
+        activation_modules: Optional[list[str]] = None,
+        run_frequency: int = _DEFAULT_RUN_FREQUENCY,
+        connector_tag_ids: Optional[list[int]] = None,
+        perimeter_scan: bool = False,
+        scan_config: Optional[dict] = None,
+        app_modules: Optional[list[str]] = None,
+    ) -> ConnectorResult:
+        activation_modules = list(activation_modules or [])
+
+        base_result = dict(
+            subscription_id=subscription_id,
+            subscription_name=subscription_name,
+            connector_name=connector_name,
+            management_group=management_group,
+        )
+
+        body = _build_create_xml(
+            name=connector_name,
+            description=f"Auto-created — subscription {subscription_id}",
+            subscription_id=subscription_id,
+            directory_id=directory_id,
+            application_id=application_id,
+            authentication_key=authentication_key,
+            is_gov_cloud=is_gov_cloud,
+            activation_modules=activation_modules,
+            run_frequency=run_frequency,
+            connector_tag_ids=connector_tag_ids or [],
+            perimeter_scan=perimeter_scan,
+            scan_config=scan_config,
+            app_modules=app_modules,
+        )
+
+        log.info("Updating connector id=%s '%s' (%s)", connector_id, connector_name, subscription_id)
+        try:
+            resp = self._post(f"{_UPDATE_PATH}/{connector_id}", body)
+        except requests.RequestException as exc:
+            return ConnectorResult(**base_result, success=False, status="failed", note=str(exc))
+
+        log.debug("Response %d: %s", resp.status_code, resp.text[:400])
+
+        http_err = _classify_http_error(resp.status_code)
+        if http_err:
+            log.warning("  ✗ %s: %s", subscription_id, http_err)
+            return ConnectorResult(**base_result, success=False, status="failed", note=http_err)
+
+        try:
+            root = ET.fromstring(resp.text)
+        except ET.ParseError as exc:
+            note = f"XML parse error: {exc}"
+            return ConnectorResult(**base_result, success=False, status="failed", note=note)
+
+        code = root.findtext("responseCode", "")
+        if code == "SUCCESS":
+            log.info("  ✓ id=%s updated", connector_id)
+            return ConnectorResult(
+                **base_result, success=True,
+                connector_id=connector_id, status="updated",
+            )
+
+        err = (
+            root.findtext("responseErrorDetails/errorMessage")
+            or root.findtext("responseMessage")
+            or "Unknown error"
+        )
+        if code in _PERMISSION_CODES:
+            err = f"{code}: {err}. {_PERMISSION_GUIDANCE}"
+        else:
+            err = f"{code}: {err}"
+        log.warning("  ✗ %s: %s", subscription_id, err)
+        return ConnectorResult(**base_result, success=False, status="failed", note=err)
 
     def resolve_tag_names(self, tag_names: list[str]) -> list[int]:
         log.info("Resolving %d tag name(s): %s", len(tag_names), tag_names)
@@ -563,6 +767,26 @@ class QualysClient:
             log.warning("  ✗ Exception enabling %s: %s", connector_id, exc)
             return False, str(exc)
 
+    def delete_connector(self, connector_id: str) -> tuple[bool, str]:
+        """Delete a connector by ID. Returns (success, message)."""
+        log.info("Deleting connector id=%s", connector_id)
+        try:
+            resp = self._session.post(
+                f"{self._base}{_DELETE_PATH}/{connector_id}",
+                data=b"", auth=self._auth, timeout=30,
+            )
+            log.debug("  delete HTTP %d", resp.status_code)
+            root = ET.fromstring(resp.text)
+            if root.findtext("responseCode") == "SUCCESS":
+                log.info("  ✓ Connector %s deleted", connector_id)
+                return True, "deleted"
+            err = root.findtext("responseErrorDetails/errorMessage") or f"HTTP {resp.status_code}"
+            log.warning("  ✗ Failed to delete %s: %s", connector_id, err)
+            return False, err
+        except Exception as exc:
+            log.warning("  ✗ Exception deleting %s: %s", connector_id, exc)
+            return False, str(exc)
+
     def disable_orphan_connectors(
         self,
         active_subscription_ids: set[str],
@@ -608,14 +832,17 @@ class QualysClient:
         application_id: str,
         authentication_key: str,
         is_gov_cloud: bool = True,
-        app_type: str = "CSA",
         activation_modules: Optional[list[str]] = None,
         run_frequency: int = _DEFAULT_RUN_FREQUENCY,
         connector_tag_ids: Optional[list[int]] = None,
-        asset_tag_ids: Optional[list[int]] = None,
         parallel: int = 1,
         delay_between: float = 2.0,
         skip_if_exists: bool = True,
+        name_prefix: str = "",
+        name_suffix: str = "",
+        perimeter_scan: bool = False,
+        scan_config: Optional[dict] = None,
+        app_modules: Optional[list[str]] = None,
     ) -> list[ConnectorResult]:
         """
         Create connectors for all subscriptions.
@@ -624,13 +851,12 @@ class QualysClient:
         to avoid bursting Qualys rate limits.
         """
         log.info(
-            "Bulk create — %d subscription(s)  app_type=%s  activation=%s  "
-            "freq=%d min  gov=%s  parallel=%d  delay=%.1fs",
-            len(subscriptions), app_type, activation_modules or [],
-            run_frequency, is_gov_cloud, parallel, delay_between,
+            "Bulk create — %d subscription(s)  activation=%s  "
+            "freq=%d min  gov=%s  perimeter_scan=%s  parallel=%d  delay=%.1fs",
+            len(subscriptions), activation_modules or [],
+            run_frequency, is_gov_cloud, perimeter_scan, parallel, delay_between,
         )
         total = len(subscriptions)
-        # Pre-allocate result slots so we preserve input order regardless of thread completion order
         results_map: dict[int, ConnectorResult] = {}
         lock = threading.Lock()
 
@@ -638,10 +864,7 @@ class QualysClient:
             sub_id    = sub["subscriptionId"]
             disp      = sub.get("displayName", "")
             mg        = sub.get("managementGroupName", "")
-            conn_name = resolve_connector_name(disp, sub_id)
-            desc      = f"Auto-created — subscription {sub_id}"
-            if mg:
-                desc += f" (MG: {mg})"
+            conn_name = resolve_connector_name(disp, sub_id, prefix=name_prefix, suffix=name_suffix)
             log.info("[%d/%d] %s", idx, total, conn_name)
             result = self.create_connector(
                 connector_name=conn_name,
@@ -651,15 +874,17 @@ class QualysClient:
                 directory_id=directory_id,
                 application_id=application_id,
                 authentication_key=authentication_key,
-                description=desc,
+                description=f"Auto-created — subscription {sub_id}",
                 is_gov_cloud=is_gov_cloud,
-                app_type=app_type,
                 activation_modules=activation_modules,
                 run_frequency=run_frequency,
                 connector_tag_ids=connector_tag_ids,
-                asset_tag_ids=asset_tag_ids,
                 skip_if_exists=skip_if_exists,
+                perimeter_scan=perimeter_scan,
+                scan_config=scan_config,
+                app_modules=app_modules,
             )
+
             with lock:
                 results_map[idx] = result
             return idx, result

--- a/Connectors/Azure/TenantConnector/requirements.txt
+++ b/Connectors/Azure/TenantConnector/requirements.txt
@@ -2,6 +2,6 @@ azure-identity==1.17.1
 azure-mgmt-resource==23.1.1
 azure-mgmt-managementgroups==1.0.0
 azure-mgmt-subscription==3.1.1
-requests==2.31.0
+requests==2.33.0
 six>=1.16.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2

--- a/Connectors/Azure/TenantConnector/requirements.txt
+++ b/Connectors/Azure/TenantConnector/requirements.txt
@@ -3,4 +3,5 @@ azure-mgmt-resource==23.1.1
 azure-mgmt-managementgroups==1.0.0
 azure-mgmt-subscription==3.1.1
 requests==2.31.0
+six>=1.16.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary

- **Perimeter scan (CPS)** — full support for `perimeterScan: true` in both `create` and `update`, with global schedule (default) and custom schedule (`perimeterScanConfig` with optionProfileId, recurrence, days, time, timezone, prefix)
- **Update subcommand** — `main.py update --all` reads `connectors.csv` and updates all tracked connectors (activation, frequency, modules, perimeter scan on/off)
- **Input validation** — three new pre-flight checks added to `main.py`:
  - `runFrequency` must be one of `{60, 120, 180, 240, 360, 480, 720, 1440}` minutes
  - `perimeterScan: true` requires `"VM"` in `activation`
  - `CI` or `CSA` in `appModules` requires the full `["AI", "CI", "CSA"]` bundle
- **`qualys_client.py`** — added `update_connector`, `delete_connector`, `verify_access` methods; improved HTTP error classification with actionable messages
- **`config.example.json`** — updated to match new schema (`appModules`, `perimeterScan`, `perimeterScanConfig`)
- **`.gitignore`** — excludes test run dirs, `connectors.csv`, `_live_test.py`

## Test plan

- [x] Ran 38-case live integration test against CA1 GovCloud (QA management group, 2 subscriptions)
- [x] S1: 16/16 create → delete cases PASS (all module combos, global + custom perimeter)
- [x] S2: 22/22 lifecycle cases PASS (create → update → delete, including freq changes, module switches, perimeter enable/disable/switch)
- [x] Validation errors verified for bad frequency, perimeterScan without VM, CSA without full bundle