### PR TITLE
fix: bump requests to 2.33.0 in Splunk Integration (Dependabot)

### DIFF
--- a/TotalCloud CSPM Splunk Integration/requirements.txt
+++ b/TotalCloud CSPM Splunk Integration/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.28.2
+requests==2.33.0
 PyYAML==6.0


### PR DESCRIPTION
## Summary

- Bumps `requests` from `2.28.2` to `2.33.0` in `TotalCloud CSPM Splunk Integration/requirements.txt`
- Resolves 4 open Dependabot alerts (moderate severity) on this path

## Test plan

- [ ] Verify Splunk Integration still runs correctly with requests 2.33.0
- [ ] Confirm Dependabot alerts close after merge